### PR TITLE
New API Endpoints

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -40,3 +40,8 @@ jobs:
     - name: Test with unittest
       run: |
         python3 -m unittest -v test_module.py
+    - name: Check test code coverage
+      run: bash <(curl -s https://codecov.io/bash)
+      env:
+        CODECOV_TOKEN: "c5555b24-0ed7-4219-97c4-96b5ad4f8129"
+        

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -40,8 +40,5 @@ jobs:
     - name: Test with unittest
       run: |
         python3 -m unittest -v test_module.py
-    - name: Check test code coverage
-      run: bash <(curl -s https://codecov.io/bash)
-      env:
-        CODECOV_TOKEN: "c5555b24-0ed7-4219-97c4-96b5ad4f8129"
+
         

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ setup_notes.md
 
 #logging
 *.log
+
+#dev testing
+vic.py

--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -150,7 +150,6 @@ class Navigator(object, metaclass=Singleton):
             Requires pysocks
             Proxy must be running."""
         self.logger.info("Enabling proxies: http=%r https=%r", http, https)
-        glo
 
     def _use_tor(self):
         self.logger.info("Setting tor as the proxy")

--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -51,10 +51,21 @@ elif sys.platform.startswith("win"):
     _TOR_CONTROL = 9151
 
 
-class Navigator(object):
+class Singleton(type):
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args,
+                                                                 **kwargs)
+        return cls._instances[cls]
+
+
+class Navigator(object, metaclass=Singleton):
     """I did not call it browser because there are other packages with
     that exact name. -Victor
     """
+
     def __init__(self):
         # TODO: Implement Singleton pattern since we don't need multiple navs.
         super(Navigator, self).__init__()
@@ -134,17 +145,14 @@ class Navigator(object):
             self.logger.info(err)
             return False
 
-    def use_proxy(self, http: str, https: str):
+    def _use_proxy(self, http: str, https: str):
         """ Routes scholarly through a proxy (e.g. tor).
             Requires pysocks
             Proxy must be running."""
         self.logger.info("Enabling proxies: http=%r https=%r", http, https)
-        _PROXIES = {
-            "http": http,
-            "https": https,
-        }
+        glo
 
-    def use_tor(self):
+    def _use_tor(self):
         self.logger.info("Setting tor as the proxy")
         self._use_proxy(http=_TOR_SOCK,
                         https=_TOR_SOCK)
@@ -160,7 +168,6 @@ class Navigator(object):
 
     def _get_soup(self, url: str) -> BeautifulSoup:
         """Return the BeautifulSoup for a page on scholar.google.com"""
-        print(_HOST.format(url))
         html = self._get_page(_HOST.format(url))
         html = html.replace(u'\xa0', u' ')
         res = BeautifulSoup(html, 'html.parser')

--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -15,6 +15,7 @@ from stem.control import Controller
 from fake_useragent import UserAgent
 from .publication import _SearchScholarIterator
 from .author import Author
+from .publication import Publication
 import sys
 
 _GOOGLEID = hashlib.md5(str(random.random()).encode('utf-8')).hexdigest()[:16]
@@ -26,6 +27,7 @@ _HEADERS = {
 _HOST = 'https://scholar.google.com{0}'
 
 _SCHOLARCITERE = r'gs_ocit\(event,\'([\w-]*)\''
+_PUBSEARCH = '"/scholar?hl=en&q={0}"'
 
 _TIMEOUT = 2
 
@@ -158,6 +160,7 @@ class Navigator(object):
 
     def _get_soup(self, url: str) -> BeautifulSoup:
         """Return the BeautifulSoup for a page on scholar.google.com"""
+        print(_HOST.format(url))
         html = self._get_page(_HOST.format(url))
         html = html.replace(u'\xa0', u' ')
         res = BeautifulSoup(html, 'html.parser')
@@ -186,6 +189,14 @@ class Navigator(object):
             else:
                 self.logger.info("No more author pages")
                 break
+
+    def search_publication(self, url: str, filled: bool = False) -> Publication:
+        """Search by scholar query and return a single Publication object"""
+        soup = self._get_soup(url)
+        res = Publication(self, soup.find_all('div', 'gs_or')[0], 'scholar')
+        if filled:
+            res.fill()
+        return res
 
     def search_publications(self, url: str) -> _SearchScholarIterator:
         return _SearchScholarIterator(self, url)

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -12,21 +12,13 @@ class _Scholarly(object):
     def __init__(self):
         self.nav = Navigator()
 
+    def use_proxy(self, http: str, https: str):
+        self.nav._use_proxy(http, https)
+
     def search_pubs(self, query):
         """Search by query and returns a generator of Publication objects"""
         url = _PUBSEARCH.format(requests.utils.quote(query))
         return self.nav.search_publications(url)
-
-    def search_pub_list(self, publist: list, filled=False):
-        """Searches for the first publication for each term in the list"""
-        assert isinstance(publist, list)
-        for i in publist:
-            yield self.search_single_pub(i, filled)
-
-    def search_terms(self, termlist: list, filled=False) -> dict:
-        """Searches for each term in a list an returns dict of generators"""
-        assert isinstance(termlist, list)
-        return {i: self.search_pubs(i) for i in termlist}
 
     def search_single_pub(self, pub_title: str, filled: bool = False):
         """Search by scholar query and return a single Publication object"""

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -17,6 +17,22 @@ class _Scholarly(object):
         url = _PUBSEARCH.format(requests.utils.quote(query))
         return self.nav.search_publications(url)
 
+    def search_pub_list(self, publist: list, filled=False):
+        """Searches for the first publication for each term in the list"""
+        assert isinstance(publist, list)
+        for i in publist:
+            yield self.search_single_pub(i, filled)
+
+    def search_terms(self, termlist: list, filled=False) -> dict:
+        """Searches for each term in a list an returns dict of generators"""
+        assert isinstance(termlist, list)
+        return {i: self.search_pubs(i) for i in termlist}
+
+    def search_single_pub(self, pub_title: str, filled: bool = False):
+        """Search by scholar query and return a single Publication object"""
+        url = _PUBSEARCH.format(requests.utils.quote(pub_title))
+        return self.nav.search_publication(url, filled)
+
     def search_author(self, name):
         """Search by author name and return a generator of Author objects"""
         url = _AUTHSEARCH.format(requests.utils.quote(name))


### PR DESCRIPTION
- `search_single pub`  allows for searching a single publication using a term or title.
- `search_pub_list` allows the user to pass a list of terms and get the first publication for each of them
- `search_terms` allows the user to search a list of terms and get publication generators for each of them as a dictionary.

Example usage:

```python
from scholarly import scholarly

result = scholarly.search_single_pub('clustering')
print(result)

results = scholarly.search_pub_list(['clustering', 'statistics'])
while True:
    try:
        print(next(results))
    except StopIteration:
        break

results = scholarly.search_terms(["moba games", 'algebraic topology'])
print(results)
```