### PR TITLE
fix: Make additional params optional in launch_tor

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ print(author)
 #### `scholarly.launch_tor()`
 
 If you have Tor installed locally, this option allows scholarly to launch its own Tor process.
-You need to pass a pointer to the Tor executable in your syste,
+You need to pass a pointer to the Tor executable in your system
 
 ```python
 from scholarly import scholarly

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -61,7 +61,7 @@ class _Scholarly:
         return self.__nav._setup_tor(tor_sock_port, tor_control_port, tor_pw)
 
     def launch_tor(self,
-                   tor_path: str, tor_sock_port: int, tor_control_port: int):
+                   tor_path: str, tor_sock_port: int = None, tor_control_port: int = None):
         """
         Launches a temporary Tor connector to be used by scholarly.
 


### PR DESCRIPTION
- Make tor_control_port and tor_sock_port optional to match
example