### PR TITLE
Add search by author id

### DIFF
--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -345,3 +345,18 @@ class Navigator(object, metaclass=Singleton):
         :rtype: {_SearchScholarIterator}
         """
         return _SearchScholarIterator(self, url)
+
+    def search_author_id(self, id: str, filled: bool = False) -> Author:
+        """Search by author ID and return a Author object
+        :param id: the Google Scholar id of a particular author
+        :type url: str
+        :param filled: If the returned Author object should be filled
+        :type filled: bool, optional
+        :returns: an Author object
+        :rtype: {Author}
+        """
+        if filled:
+            res = Author(self, id).fill()
+        else:
+            res = Author(self, id).fill(sections=['basics'])
+        return res

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -192,7 +192,7 @@ class _Scholarly:
             .. testcode::
 
                 search_query = scholarly.search_author_id('EmD_lTEAAAAJ')
-                print(next(search_query))
+                print(search_query)
 
         :Output::
 

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -184,6 +184,28 @@ class _Scholarly:
         url = _AUTHSEARCH.format(requests.utils.quote(name))
         return self.__nav.search_authors(url)
 
+    def search_author_id(self, id: str, filled: bool = False):
+        """Search by author id and return a single Author object
+
+        :Example::
+
+            .. testcode::
+
+                search_query = scholarly.search_author_id('EmD_lTEAAAAJ')
+                print(next(search_query))
+
+        :Output::
+
+            .. testoutput::
+
+                {'affiliation': 'Institut du radium, University of Paris',
+                 'filled': False,
+                 'id': 'EmD_lTEAAAAJ',
+                 'interests': [],
+                 'name': 'Marie Skłodowska-Curie'}
+        """
+        return self.__nav.search_author_id(id, filled)
+
     def search_keyword(self, keyword: str):
         """Search by keyword and return a generator of Author objects
 

--- a/test_module.py
+++ b/test_module.py
@@ -146,6 +146,20 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(author.affiliation,
                          u'Institut du radium, University of Paris')
 
+    def test_search_author_id_filled(self):
+        """
+        Test the search by author ID. Marie Skłodowska-Curie's ID is
+        EmD_lTEAAAAJ and these IDs are permenant.
+        As of July 2020, Marie Skłodowska-Curie has 1963 citations
+        on Google Scholar and 179 publications
+        """
+        author = scholarly.search_author_id('EmD_lTEAAAAJ', filled=True)
+        self.assertEqual(author.name, u'Marie Skłodowska-Curie')
+        self.assertEqual(author.affiliation,
+                         u'Institut du radium, University of Paris')
+        self.assertGreaterEqual(author.citedby, 1963)
+        self.assertGreaterEqual(len(author.publications), 179)
+
     def test_search_pubs(self):
         """
         As of May 12, 2020 there are at least 29 pubs that fit the search term:

--- a/test_module.py
+++ b/test_module.py
@@ -136,6 +136,16 @@ class TestScholarly(unittest.TestCase):
         self.assertGreaterEqual(len(authors), 24)
         self.assertIn(u'Giordano Cattani', authors)
 
+    def test_search_author_id(self):
+        """
+        Test the search by author ID. Marie Skłodowska-Curie's ID is
+        EmD_lTEAAAAJ and these IDs are permenant
+        """
+        author = scholarly.search_author_id('EmD_lTEAAAAJ')
+        self.assertEqual(author.name, u'Marie Skłodowska-Curie')
+        self.assertEqual(author.affiliation,
+                         u'Institut du radium, University of Paris')
+
     def test_search_pubs(self):
         """
         As of May 12, 2020 there are at least 29 pubs that fit the search term:


### PR DESCRIPTION
Adds a `scholarly.search_author_id` function for easy pulling of citations for a known author (presumably often oneself).

Basically exploit the method used for `Author._fill_coauthors` of passing an `id` as `__data` to `Author` but to make it useful either do just a basic fill or, if requested, do a full fill.

Closes #106 