### PR TITLE
Features/add field author id to publication object

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ PORT = <PORT_FOR_LUMINATY>
 To run tests execute the `test_module.py` file as:
 
 ```bash
-python3 test_module
+python3 test_module.py
 ```
 
 or

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ print([citation.bib['title'] for citation in pub.citedby])
                      'perceived critical angle, ie, the tilt angle at which '
                      'the object',
          'author': ['SA Cholewiak', 'RW Fleming', 'M Singh'],
+         'author_id': ['4bahYMkAAAAJ', '3xJXtlwAAAAJ', 'Smr99uEAAAAJ'],
          'cites': '23',
          'eprint': 'https://jov.arvojournals.org/article.aspx?articleID=2213254',
          'gsrank': '1',
@@ -123,6 +124,9 @@ print([citation.bib['title'] for citation in pub.citedby])
  'url_add_sclib': '/citations?hl=en&xsrf=&continue=/scholar%3Fq%3DPerception%2Bof%2Bphysical%2Bstability%2Band%2Bcenter%2Bof%2Bmass%2Bof%2B3D%2Bobjects%26hl%3Den%26as_sdt%3D0,33&citilm=1&json=&update_op=library_add&info=K8ZpoI6hZNoJ&ei=ewEtX7_JOIvrmQHcvJqoDA',
  'url_scholarbib': '/scholar?q=info:K8ZpoI6hZNoJ:scholar.google.com/&output=cite&scirp=0&hl=en'}
 ```
+
+Please note that the `author_id` array is positionally matching the `author` array. 
+You can use the `author_id` to get further details about the author using the `search_author_id` method.    
 
 ### Methods for `Publication` objects
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ print([citation.bib['title'] for citation in pub.citedby])
  'url_scholarbib': '/scholar?q=info:K8ZpoI6hZNoJ:scholar.google.com/&output=cite&scirp=0&hl=en'}
 ```
 
-Please note that the `author_id` array is positionally matching the `author` array. 
+Please note that the `author_id` array is positionally matching with the `author` array. 
 You can use the `author_id` to get further details about the author using the `search_author_id` method.    
 
 ### Methods for `Publication` objects

--- a/scholarly/publication.py
+++ b/scholarly/publication.py
@@ -103,6 +103,18 @@ class Publication(object):
             authorlist.append(i)
         return authorlist
 
+    def _get_author_id_list(self, authorinfo_inner_html):
+        author_id_list = list()
+        html = authorinfo_inner_html.split(' - ')[0]
+        for author_html in html.split(','):
+            author_html = author_html.strip()
+            match = re.search('\\?user=(.*?)&amp;', author_html)
+            if match:
+                author_id_list.append(match.groups()[0])
+            else:
+                author_id_list.append(None)
+        return author_id_list
+
     def _scholar_pub(self, __data):
         databox = __data.find('div', class_='gs_ri')
         title = databox.find('h3', class_='gs_rt')
@@ -122,10 +134,13 @@ class Publication(object):
         if title.find('a'):
             self.bib['url'] = title.find('a')['href']
 
-        authorinfo = databox.find('div', class_='gs_a').text
+        author_div_element = databox.find('div', class_='gs_a')
+        authorinfo = author_div_element.text
         authorinfo = authorinfo.replace(u'\xa0', u' ')       # NBSP
         authorinfo = authorinfo.replace(u'&amp;', u'&')      # Ampersand
         self.bib["author"] = self._get_authorlist(authorinfo)
+        authorinfo_html = author_div_element.decode_contents()
+        self.bib["author_id"] = self._get_author_id_list(authorinfo_html)
 
         # There are 4 (known) patterns in the author/venue/year/host line:
         #  (A) authors - host
@@ -231,15 +246,15 @@ class Publication(object):
                     # try to find all the gsh_csp if they exist
                     abstract = val.find_all(class_='gsh_csp')
                     result = ""
-                    
+
                     # append all gsh_csp together as there can be multiple in certain scenarios
                     for item in abstract:
                         if item.text[0:8].lower() == 'abstract':
                             result += item.text[9:].strip()
                         else:
                             result += item.text
-                    
-                    if len(abstract) == 0: # if no gsh_csp were found 
+
+                    if len(abstract) == 0: # if no gsh_csp were found
                         abstract = val.find(class_='gsh_small')
                         if abstract.text[0:8].lower() == 'abstract':
                             result = abstract.text[9:].strip()

--- a/scholarly/publication.py
+++ b/scholarly/publication.py
@@ -215,6 +215,7 @@ class Publication(object):
         if self.source == 'citations':
             url = _CITATIONPUB.format(self.id_citations)
             soup = self.nav._get_soup(url)
+            print(f'in pub.fill(2): \nsoup={soup}')
             self.bib['title'] = soup.find('div', id='gsc_vcd_title').text
             if soup.find('a', class_='gsc_vcd_title_link'):
                 self.bib['url'] = soup.find(
@@ -222,7 +223,7 @@ class Publication(object):
             for item in soup.find_all('div', class_='gs_scl'):
                 key = item.find(class_='gsc_vcd_field').text.strip().lower()
                 val = item.find(class_='gsc_vcd_value')
-                print(f'in pub.fill(2): \nitem={item}\nkey={key}\nval={val}')
+                print(f'in pub.fill(3): \nitem={item}\nkey={key}\nval={val}')
                 if key == 'authors':
                     self.bib['author'] = ' and '.join(
                         [i.strip() for i in val.text.split(',')])

--- a/scholarly/publication.py
+++ b/scholarly/publication.py
@@ -63,6 +63,7 @@ class Publication(object):
     """Returns an object for a single publication"""
 
     def __init__(self, nav, __data, pubtype=None):
+        print(f'in pub.init: \npubtype={pubtype} \n__data={__data}')
         self.nav = nav
         self.bib = dict()
         self.source = pubtype
@@ -210,6 +211,7 @@ class Publication(object):
 
     def fill(self):
         """Populate the Publication with information from its profile"""
+        print(f'in pub.fill(1): \nself.source={self.source} \nself.bib={self.bib}')
         if self.source == 'citations':
             url = _CITATIONPUB.format(self.id_citations)
             soup = self.nav._get_soup(url)
@@ -220,6 +222,7 @@ class Publication(object):
             for item in soup.find_all('div', class_='gs_scl'):
                 key = item.find(class_='gsc_vcd_field').text.strip().lower()
                 val = item.find(class_='gsc_vcd_value')
+                print(f'in pub.fill(2): \nitem={item}\nkey={key}\nval={val}')
                 if key == 'authors':
                     self.bib['author'] = ' and '.join(
                         [i.strip() for i in val.text.split(',')])

--- a/test_module.py
+++ b/test_module.py
@@ -222,7 +222,7 @@ class TestScholarly(unittest.TestCase):
 
     def test_extract_author_id_list(self):
         '''
-        This test the extraction of the id of the authors from the html to  populate the author_id field
+        This unit test tests the extraction of the author id field from the html to populate the `author_id` field
         in the Publication object.
         '''
         author_html_full = '<a href="/citations?user=4bahYMkAAAAJ&amp;hl=en&amp;oi=sra">SA Cholewiak</a>, <a href="/citations?user=3xJXtlwAAAAJ&amp;hl=en&amp;oi=sra">GD Love</a>, <a href="/citations?user=Smr99uEAAAAJ&amp;hl=en&amp;oi=sra">MS Banks</a> - Journal of vision, 2018 - jov.arvojournals.org'

--- a/test_module.py
+++ b/test_module.py
@@ -106,6 +106,7 @@ class TestScholarly(unittest.TestCase):
          author = authors[0].fill()
          # Check that we can fill without problem the first two publications
          publications = author.publications[:2]
+         print(f'in test_search_author_filling_author_publications before fill: publications:{publications}\n\n-----\n\n')
          for i in publications:
              i.fill()
          self.assertEqual(len(publications), 2)


### PR DESCRIPTION
Hello Scholarly team,

thank you for your work it has been very useful for a side project I just did.

I would like to contribute a small feature added during that project: a new field, `author_id` returned while searching for publications, i.e. `search_pubs` methods.

The new field contains a list of `author_id` positionally matching with the `author` field.
Example from the test with highlighted the new `author_id` field:

```
query = 'Creating correct blur and its effect on accommodation'
        results = scholarly.search_pubs(query)
        pubs = [p for p in results]
        self.assertGreaterEqual(len(pubs), 1)
        f = pubs[0].fill()
        self.assertTrue(f.bib['author'] == u'Cholewiak, Steven A and Love, Gordon D and Banks, Martin S')
        **self.assertTrue(f.bib['author_id'] == ['4bahYMkAAAAJ', '3xJXtlwAAAAJ', 'Smr99uEAAAAJ'])**
        self.assertTrue(f.bib['journal'] == u'Journal of vision')
        self.assertTrue(f.bib['number'] == u'9')
        self.assertTrue(f.bib['pages'] == u'1--1')
        self.assertTrue(f.bib['publisher'] == u'The Association for Research in Vision and Ophthalmology')
        self.assertTrue(f.bib['title'] == u'Creating correct blur and its effect on accommodation')
        self.assertTrue(f.bib['url'] == u'https://jov.arvojournals.org/article.aspx?articleid=2701817')
        self.assertTrue(f.bib['volume'] == u'18')
        self.assertTrue(f.bib['year'] == u'2018')
```
