### PR TITLE
Fixed bug that bibtex export fails if author_ids are (partly) missing

### DIFF
--- a/scholarly/publication.py
+++ b/scholarly/publication.py
@@ -309,6 +309,9 @@ class Publication(object):
             self.fill()
         a = BibDatabase()
         converted_dict = self.bib
+        if not 'author_id' in converted_dict:
+            converted_dict['author_id'] = []
+        converted_dict['author_id'] = [i for i in converted_dict['author_id'] if i]
         converted_dict['author_id'] = ', '.join(converted_dict['author_id'])
         a.entries = [converted_dict]
         return bibtexparser.dumps(a)


### PR DESCRIPTION
In some cases, if the author_id field is missing in the publication, the bibtex export will crash with an error message. This also happens when some of the author_id elements are "None". In this case, the None elements are removed and if necessary, an empty author_id key is generated so that bibtex export can proceed.