### PR TITLE
Update setup.py for to require typing_extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setuptools.setup(
                       'python-dotenv',
                       'free-proxy',
                       'sphinx_rtd_theme',
+                      'typing_extensions'
                       ],
     test_suite="test_module.py"
 )


### PR DESCRIPTION
Otherwise ModuleNotFoundError: No module named 'typing_extensions'