### PR TITLE
Fix cittedby for author page publications with multiple citeids

### DIFF
--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -7,7 +7,7 @@ from .data_types import BibEntry, Publication, PublicationSource
 
 
 _HOST = 'https://scholar.google.com{0}'
-_SCHOLARPUBRE = r'cites=([\w-]*)'
+_SCHOLARPUBRE = r'cites=([\d,]*)'
 _CITATIONPUB = '/citations?hl=en&view_op=view_citation&citation_for_view={0}'
 _SCHOLARPUB = '/scholar?hl=en&oi=bibs&cites={0}'
 _CITATIONPUBRE = r'citation_for_view=([\w-]*:[\w-]*)'


### PR DESCRIPTION

In author pages, a publication can aggregate together different google scholar citeids separated by comas like so : 
https://scholar.google.fr/scholar?oi=bibs&hl=fr&cites=13804486329402855616,16026341598281412798,10132482875122586386,14743974300235144616&as_sdt=5
The current version only picks the first id which is a shame.
Changing the regexp seems to work just fine, but i don't know if it might break something elsewhere.