### PR TITLE
Bug in Pickle protocol for SearchScholarIterator

### DIFF
--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -82,6 +82,7 @@ class _SearchScholarIterator(object):
         elif self._soup.find(class_='gs_ico gs_ico_nav_next'):
             url = self._soup.find(
                 class_='gs_ico gs_ico_nav_next').parent['href']
+            self._url = url
             self._load_url(url)
             return self.__next__()
         else:


### PR DESCRIPTION
I am using the Pickle protocol for SearchScholarIterator to restore the state of the iterator when the scraper fails.
When advancing the search to a new page (from 2 onwards), the new url should be stored in the "self._url" field.