### PR TITLE
ScraperAPI and random UserAgent

### DIFF
--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -101,7 +101,13 @@ class Navigator(object, metaclass=Singleton):
             try:
                 w = random.uniform(1,2)
                 time.sleep(w)
-                resp = self._session.get(pagerequest, timeout=timeout)
+                
+                params = {}
+                if self.pm._ScraperAPI_KEY:
+                    params = { 'api_key': self.pm._ScraperAPI_KEY, 'url': pagerequest }
+                    pagerequest = 'http://api.scraperapi.com'
+                
+                resp = self._session.get(pagerequest, params=params, timeout=timeout)
                 self.logger.info("Session proxy config is {}".format(self._session.proxies))
 
                 has_captcha = self._requests_has_captcha(resp.text)

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -367,7 +367,7 @@ class ProxyGenerator(object):
         _HEADERS = {
             'accept-language': 'en-US,en',
             'accept': 'text/html,application/xhtml+xml,application/xml',
-            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36',
+            'User-Agent': UserAgent().random,
         }
         self._session.headers.update(_HEADERS)
 

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -45,6 +45,7 @@ class ProxyGenerator(object):
         # If we use a proxy or Tor, we set this to True
         self._proxy_works = False
         self._use_luminati = False
+        self._ScraperAPI_KEY = None
         # If we h:ve a Tor server that we can refresh, we set this to True
         self._tor_process = None
         self._can_refresh_tor = False
@@ -395,6 +396,22 @@ class ProxyGenerator(object):
             proxy_works = self._use_proxy(http=proxy, https=proxy)
             if proxy_works:
                 break
+
+    def ScraperAPI(self, API_KEY):
+        """
+        Sets up a proxy using ScraperAPI
+
+        :Example::
+            pg = ProxyGenerator()
+            pg.ScraperAPI(API_KEY)
+
+        :param API_KEY: ScraperAPI API Key value. 
+        :type API_KEY: string
+        """
+        assert API_KEY is not None
+        self._ScraperAPI_KEY = API_KEY
+
+        self._use_proxy(http='http://api.scraperapi.com/?api_key='+API_KEY)
 
     def has_proxy(self)-> bool:
         return self._proxy_gen or self._can_refresh_tor

--- a/test_module.py
+++ b/test_module.py
@@ -228,7 +228,13 @@ class TestScholarly(unittest.TestCase):
         author_id_list = pub_parser._get_author_id_list(author_html_partial)
         self.assertTrue(author_id_list[3] == 'TEndP-sAAAAJ')
 
+    def test_ScraperAPI(self):
+        proxy_generator = ProxyGenerator()
+        proxy_generator.ScraperAPI(os.getenv('SCRAPER_API_KEY'))
+        scholarly.set_timeout(60)
 
+        ## Uses another method to test that proxy is working.
+        self.test_search_keyword()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Ok, so I inserted changes suggested in https://github.com/scholarly-python-package/scholarly/issues/261#issuecomment-806433099.

Thanks @MoritzImendoerffer and @Sikerdebaard for their contributions in the original issue.
This fixes #261.

## ScraperAPI proxy
This adds a new proxy method with ScraperAPI. Problem is that the proxy works in a different way to the others, having to add the original pagerequest as a parameter to a request to `http://api.scraperapi.com/`.

This method receives an API key, which if defined, when getting a new page in scholarly, overrides the pagerequest with the scraperapi one. I believe this may introduce bugs, so I believe further testing from devs that know how the proxy methods work is needed, if a different method of implementation is required.

Regardless, I included a test using the new proxy method, to attest that it works, which passed, correctly proxying the request via scraperapi.

## UserAgent
It was brought up that the User-Agent header was causing blocks. I saw that the `proxy_generator` used a fixed value, even though it imports UserAgent, which generates User-Agent headers, but is never used. ec699c5d1df98803e80876d3cf61e57190091d05 fixes this.