### PR TITLE
Remove calls to logging.basicConfig

### DIFF
--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -52,7 +52,6 @@ class Navigator(object, metaclass=Singleton):
 
     def __init__(self):
         super(Navigator, self).__init__()
-        logging.basicConfig(filename='scholar.log', level=logging.CRITICAL)
         self.logger = logging.getLogger('scholarly')
         self._TIMEOUT = 5
         self._max_retries = 5

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -36,9 +36,7 @@ class Singleton(type):
 
 class ProxyGenerator(object):
     def __init__(self):
-
         # setting up logger 
-        logging.basicConfig(filename='scholar.log', level=logging.INFO)
         self.logger = logging.getLogger('scholarly')
 
         self._proxy_gen = None


### PR DESCRIPTION
This fixes breakage of logging in external packages when importing
scholarly, see #289 . Calling basicConfig() should be done in the \_\_main__ module /
the script that is executed, not in libraries.