### PR TITLE
update id for filling publication detail

### DIFF
--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -263,13 +263,13 @@ class PublicationParser(object):
         if publication['source'] == PublicationSource.AUTHOR_PUBLICATION_ENTRY:
             url = _CITATIONPUB.format(publication['author_pub_id'])
             soup = self.nav._get_soup(url)
-            publication['bib']['title'] = soup.find('div', id='gsc_vcd_title').text
-            if soup.find('a', class_='gsc_vcd_title_link'):
+            publication['bib']['title'] = soup.find('div', id='gsc_oci_title').text
+            if soup.find('a', class_='gsc_oci_title_link'):
                 publication['pub_url'] = soup.find(
-                    'a', class_='gsc_vcd_title_link')['href']
+                    'a', class_='gsc_oci_title_link')['href']
             for item in soup.find_all('div', class_='gs_scl'):
-                key = item.find(class_='gsc_vcd_field').text.strip().lower()
-                val = item.find(class_='gsc_vcd_value')
+                key = item.find(class_='gsc_oci_field').text.strip().lower()
+                val = item.find(class_='gsc_oci_value')
                 if key == 'authors' or key == 'inventors':
                     publication['bib']['author'] = ' and '.join(
                         [i.strip() for i in val.text.split(',')])
@@ -326,9 +326,9 @@ class PublicationParser(object):
                         if entry.text.lower() == 'related articles':
                             publication['url_related_articles'] = entry.get('href')[26:]
             # number of citation per year
-            years = [int(y.text) for y in soup.find_all(class_='gsc_vcd_g_t')]
-            cites = [int(c.text) for c in soup.find_all(class_='gsc_vcd_g_al')]
-            cites_year = [int(c.get('href')[-4:]) for c in soup.find_all(class_='gsc_vcd_g_a')]
+            years = [int(y.text) for y in soup.find_all(class_='gsc_oci_g_t')]
+            cites = [int(c.text) for c in soup.find_all(class_='gsc_oci_g_al')]
+            cites_year = [int(c.get('href')[-4:]) for c in soup.find_all(class_='gsc_oci_g_a')]
             nonzero_cites_per_year = dict(zip(cites_year, cites))
             res_dict = {}
             for year in years:

--- a/test_module.py
+++ b/test_module.py
@@ -202,7 +202,7 @@ class TestScholarly(unittest.TestCase):
         f = scholarly.fill(pubs[0])
         self.assertTrue(f['bib']['author'] == u'Cholewiak, Steven A and Love, Gordon D and Banks, Martin S')
         self.assertTrue(f['author_id'] == ['4bahYMkAAAAJ', '3xJXtlwAAAAJ', 'Smr99uEAAAAJ'])
-        self.assertTrue(f['bib']['journal'] == u'Journal of vision')
+        self.assertTrue(f['bib']['journal'] == u'Journal of Vision')
         self.assertTrue(f['bib']['number'] == '9')
         self.assertTrue(f['bib']['pages'] == u'1--1')
         self.assertTrue(f['bib']['publisher'] == u'The Association for Research in Vision and Ophthalmology')


### PR DESCRIPTION
Google Scholar has changed the "id" for many fields of publication detail page. This commit fixed the relevant codes in `publication_parser.py`.