### PR TITLE
fix parsing total search results

### DIFF
--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -62,10 +62,11 @@ class _SearchScholarIterator(object):
 
     def _get_total_results(self):
         for x in self._soup.find_all('div', class_='gs_ab_mdw'):
-            # Decimal separator is set by Google independent of language setting
-            match = re.match(pattern=r'(^|\s*About)\s*([0-9,\.]+)', string=x.text)
+            # Accounting for different thousands separators: 
+            # comma, dot, space, apostrophe
+            match = re.match(pattern=r'(^|\s*About)\s*([0-9,\.\s’]+)', string=x.text)
             if match:
-                return int(re.sub(pattern=r'[,\.]',repl='', string=match.group(2)))
+                return int(re.sub(pattern=r'[,\.\s’]',repl='', string=match.group(2)))
         return None
 
     # Iterator protocol

--- a/test_module.py
+++ b/test_module.py
@@ -186,12 +186,16 @@ class TestScholarly(unittest.TestCase):
     def test_search_pubs_total_results(self):
         """
         As of February 4, 2021 there are 32 pubs that fit the search term:
-        ["naive physics" stability "3d shape"].
+        ["naive physics" stability "3d shape"], and 17'000 results that fit
+        the search term ["WIEN2k Blaha"].
 
         Check that the total results for that search term equals 32.
         """
         pubs = scholarly.search_pubs('"naive physics" stability "3d shape"')
         self.assertGreaterEqual(pubs.total_results, 32)
+
+        pubs = scholarly.search_pubs('WIEN2k Blaha')
+        self.assertGreaterEqual(pubs.total_results, 10000)
 
     def test_search_pubs_filling_publication_contents(self):
         '''


### PR DESCRIPTION
The current parser for the total search results choked on results >1000
when the apostrophe was used as the thousands delimiter, e.g. 17’000.

Added test to prevent regression.