### PR TITLE
Fetch all coauthors

### DIFF
--- a/scholarly/author_parser.py
+++ b/scholarly/author_parser.py
@@ -7,6 +7,9 @@ _HOST = 'https://scholar.google.com{0}'
 _PAGESIZE = 100
 _EMAILAUTHORRE = r'Verified email at '
 _CITATIONAUTH = '/citations?hl=en&user={0}'
+_COAUTH = ('https://scholar.google.com/citations?user={0}&hl=en'
+           '#d=gsc_md_cod&u=%2Fcitations%3Fview_op%3Dlist_colleagues'
+           '%26hl%3Den%26json%3D%26user%3D{0}%23t%3Dgsc_cod_lc')
 
 
 class AuthorParser:
@@ -19,7 +22,7 @@ class AuthorParser:
                           'counts',
                           'coauthors',
                           'publications'}
-    
+
     def get_author(self, __data)->Author:
         """ Fills the information for an author container
         """
@@ -135,13 +138,40 @@ class AuthorParser:
                 break
 
     def _fill_coauthors(self, soup, author):
+        if not soup.find_all('button', id='gsc_coauth_opn'):
+            # If "View All" is not found, scrape the page for coauthors
+            coauthors = soup.find_all('span', class_='gsc_rsb_a_desc')
+            coauthor_ids = [re.findall(_CITATIONAUTHRE,
+                            coauth('a')[0].get('href'))[0]
+                            for coauth in coauthors]
+
+            coauthor_names = [coauth.find(tabindex="-1").text
+                              for coauth in coauthors]
+            coauthor_affils = [coauth.find(class_="gsc_rsb_a_ext").text
+                               for coauth in coauthors]
+        else:
+            # Open the dialog box to get all coauthors
+            wd = self.nav.pm._get_webdriver()
+            wd.get(_COAUTH.format(author['scholar_id']))
+            # Wait up to 30 seconds for the various elements to be available.
+            # The wait may be better set elsewhere.
+            wd.implicitly_wait(30)
+            coauthors = wd.find_elements_by_class_name('gs_ai_pho')
+            coauthor_ids = [re.findall(_CITATIONAUTHRE,
+                            coauth.get_attribute('href'))[0]
+                            for coauth in coauthors]
+            coauthor_names = [name.text for name in
+                              wd.find_elements_by_class_name('gs_ai_name')]
+            coauthor_affils = [affil.text for affil in
+                               wd.find_elements_by_class_name('gs_ai_aff')]
+
         author['coauthors'] = []
-        for row in soup.find_all('span', class_='gsc_rsb_a_desc'):
-            new_coauthor = self.get_author(re.findall(
-                _CITATIONAUTHRE, row('a')[0]['href'])[0])
-            new_coauthor['name'] = row.find(tabindex="-1").text
-            new_coauthor['affiliation'] = row.find(
-                class_="gsc_rsb_a_ext").text
+        for coauth_id, coauth_name, coauth_affil in zip(coauthor_ids,
+                                                        coauthor_names,
+                                                        coauthor_affils):
+            new_coauthor = self.get_author(coauth_id)
+            new_coauthor['name'] = coauth_name
+            new_coauthor['affiliation'] = coauth_affil
             new_coauthor['source'] = AuthorSource.CO_AUTHORS_LIST
             author['coauthors'].append(new_coauthor)
 

--- a/test_module.py
+++ b/test_module.py
@@ -146,6 +146,7 @@ class TestScholarly(unittest.TestCase):
         author = scholarly.fill(authors[0])
         self.assertEqual(author['name'], u'Steven A. Cholewiak, PhD')
         self.assertEqual(author['scholar_id'], u'4bahYMkAAAAJ')        
+        self.assertGreaterEqual(len(author['coauthors']), 33)
         pub = scholarly.fill(author['publications'][2])
         self.assertEqual(pub['author_pub_id'],u'4bahYMkAAAAJ:LI9QrySNdTsC')
 


### PR DESCRIPTION
This PR addresses issue #316.

When a scholar profile has more than 20 coauthors, the fix opens the dialog box and fetches the whole list. There are no API changes.

Some general comments:
- Unlike the citation count histogram where the entire histogram is available even when not visible, the complete list of coauthors is never available in the source code, and therefore not accessible via `soup`. So I had to use a webdriver and find the elements corresponding to the list.
- The fix works just fine even when there are fewer than 20 coauthors. I kept the old code with an if/else switch nevertheless since fetching the elements takes a few more seconds compared to scraping. 