### PR TITLE
Fix multiple citeids

### DIFF
--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -163,7 +163,7 @@ class Publication(TypedDict, total=False):
     gsrank: int
     author_id: List[str]
     num_citations: int
-    cites_id: int
+    cites_id: List[str]
     citedby_url: str
     cites_per_year: CitesPerYear
     author_pub_id: str

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -7,7 +7,7 @@ from .data_types import BibEntry, Publication, PublicationSource
 
 
 _HOST = 'https://scholar.google.com{0}'
-_SCHOLARPUBRE = r'cites=([\w-]*)'
+_SCHOLARPUBRE = r'cites=([\d,]*)'
 _CITATIONPUB = '/citations?hl=en&view_op=view_citation&citation_for_view={0}'
 _SCHOLARPUB = '/scholar?hl=en&oi=bibs&cites={0}'
 _CITATIONPUBRE = r'citation_for_view=([\w-]*:[\w-]*)'

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -320,8 +320,8 @@ class PublicationParser(object):
                     publication['bib']['abstract'] = result
                 elif key == 'total citations':
                     publication['cites_id'] = re.findall(
-                        _SCHOLARPUBRE, val.a['href'])[0]
-                    publication['citedby_url'] = _CITEDBYLINK.format(publication['cites_id'])
+                        _SCHOLARPUBRE, val.a['href'])[0].split(',')
+                    publication['citedby_url'] = _CITEDBYLINK.format(','.join(publication['cites_id']))
                 elif key == 'scholar articles':
                     for entry in val.find_all('a'):
                         if entry.text.lower() == 'related articles':


### PR DESCRIPTION
This is an extension of PR #272 where the `cites_id` is made into a `list`, even if there is only one `cites_id` present for a publication. Here's an output of the following script:

```
from scholarly import scholarly
author = scholarly.search_author_id('5eOo9hQAAAAJ')
scholarly.fill(author)
pub = author['publications'][18]
scholarly.fill(pub)
print(pub)
```

results in 

```
{'container_type': 'Publication', 'source': <PublicationSource.AUTHOR_PUBLICATION_ENTRY: 2>, 'bib': {'title': 'Randomness increases order in biological evolution', 'pub_year': 2012, 'author': 'Giuseppe Longo and Maël Montévil', 'pages': '289-308', 'publisher': 'Springer, Berlin, Heidelberg', 'abstract': 'In this text, we revisit part of the analysis of anti-entropy in [4] and develop further theoretical reflections. In particular, we analyze how randomness, an essential component of biological variability, is associated to the growth of biological organization, both in ontogenesis and in evolution. This approach, in particular, focuses on the role of global entropy production and provides a tool for a mathematical understanding of some fundamental observations by Gould on the increasing phenotypic complexity along evolution. Lastly, we analyze the situation in terms of theoretical symmetries, in order to further specify the biological meaning of anti-entropy as well as its strong link with randomness.'}, 'filled': True, 'author_pub_id': '5eOo9hQAAAAJ:qjMakFHDy7sC', 'num_citations': 29, 'pub_url': 'https://link.springer.com/chapter/10.1007/978-3-642-27654-5_22', 'cites_id': ['13804486329402855616', '16026341598281412798', '10132482875122586386', '14743974300235144616'], 'citedby_url': '/scholar?cites=13804486329402855616,16026341598281412798,10132482875122586386,14743974300235144616', 'url_related_articles': '/scholar?oi=bibs&hl=en&q=related:EhNpoH3PnYwJ:scholar.google.com/', 'cites_per_year': {2011: 1, 2012: 0, 2013: 4, 2014: 3, 2015: 2, 2016: 6, 2017: 1, 2018: 2, 2019: 3, 2020: 2, 2021: 4}}
```

