### PR TITLE
Make scholarly objects serializable

### DIFF
--- a/scholarly/author_parser.py
+++ b/scholarly/author_parser.py
@@ -24,7 +24,7 @@ class AuthorParser:
         """ Fills the information for an author container
         """
         author: Author = {'container_type': 'Author'}
-        author['filled'] = set()
+        author['filled'] = []
         if isinstance(__data, str):
             author['scholar_id'] = __data
             author['source'] = AuthorSource.AUTHOR_PROFILE_PAGE
@@ -322,12 +322,12 @@ class AuthorParser:
                 for i in self._sections:
                     if i not in author['filled']:
                         (getattr(self, f'_fill_{i}')(soup, author) if i != 'publications' else getattr(self, f'_fill_{i}')(soup, author, publication_limit, sortby_str))
-                        author['filled'].add(i)
+                        author['filled'].append(i)
             else:
                 for i in sections:
                     if i in self._sections and i not in author['filled']:
                         (getattr(self, f'_fill_{i}')(soup, author) if i != 'publications' else getattr(self, f'_fill_{i}')(soup, author, publication_limit, sortby_str))
-                        author['filled'].add(i)
+                        author['filled'].append(i)
         except Exception as e:
             raise(e)
 

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -1,7 +1,7 @@
 import sys
 
 from enum import Enum
-from typing import List, Dict, Set
+from typing import List, Dict
 
 if sys.version_info >= (3, 8):
     from typing import TypedDict 
@@ -9,7 +9,7 @@ else:
     from typing_extensions import TypedDict
 
 
-class PublicationSource(Enum):
+class PublicationSource(int, Enum):
     '''
     Defines the source of the publication. In general, a publication 
     on Google Scholar has two forms:
@@ -62,7 +62,7 @@ class PublicationSource(Enum):
     PUBLICATION_SEARCH_SNIPPET = 1
     AUTHOR_PUBLICATION_ENTRY = 2
     
-class AuthorSource(Enum):
+class AuthorSource(int, Enum):
     '''
     Defines the source of the HTML that will be parsed.
     
@@ -187,7 +187,7 @@ class Author(TypedDict, total=False):
     :param email_domain: The email domain of the author (source: SEARCH_AUTHOR_SNIPPETS, AUTHOR_PROFILE_PAGE)
     :param url_picture: The URL for the picture of the author
     :param citedby: The number of citations to all publications. (source: SEARCH_AUTHOR_SNIPPETS)
-    :param filled: The set of sections filled out of the total set of sections that can be filled
+    :param filled: The list of sections filled out of the total set of sections that can be filled
     :param interests: Fields of interest of this Author (sources: SEARCH_AUTHOR_SNIPPETS, AUTHOR_PROFILE_PAGE)
     :param citedby5y: The number of new citations in the last 5 years to all publications. (source: SEARCH_AUTHOR_SNIPPETS)
     :param hindex: The h-index is the largest number h such that h publications have at least h citations. (source: SEARCH_AUTHOR_SNIPPETS)
@@ -208,7 +208,7 @@ class Author(TypedDict, total=False):
     email_domain: str
     url_picture: str
     citedby: int
-    filled: Set
+    filled: List[str]
     interests: List[str]
     citedby5y: int
     hindex: int

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -9,7 +9,7 @@ else:
     from typing_extensions import TypedDict
 
 
-class PublicationSource(int, Enum):
+class PublicationSource(str, Enum):
     '''
     Defines the source of the publication. In general, a publication 
     on Google Scholar has two forms:
@@ -59,10 +59,10 @@ class PublicationSource(int, Enum):
     
     Detailed view page: https://scholar.google.com/citations?view_op=view_citation&hl=en&citation_for_view=-Km63D4AAAAJ:d1gkVwhDpl0C
     '''
-    PUBLICATION_SEARCH_SNIPPET = 1
-    AUTHOR_PUBLICATION_ENTRY = 2
+    PUBLICATION_SEARCH_SNIPPET = "PUBLICATION_SEARCH_SNIPPET"
+    AUTHOR_PUBLICATION_ENTRY = "AUTHOR_PUBLICATION_ENTRY"
     
-class AuthorSource(int, Enum):
+class AuthorSource(str, Enum):
     '''
     Defines the source of the HTML that will be parsed.
     
@@ -72,9 +72,9 @@ class AuthorSource(int, Enum):
     
     Coauthors: From the list of co-authors from an Author page
     '''
-    AUTHOR_PROFILE_PAGE = 1
-    SEARCH_AUTHOR_SNIPPETS = 2
-    CO_AUTHORS_LIST = 3
+    AUTHOR_PROFILE_PAGE = "AUTHOR_PROFILE_PAGE"
+    SEARCH_AUTHOR_SNIPPETS = "SEARCH_AUTHOR_SNIPPETS"
+    CO_AUTHORS_LIST = "CO_AUTHORS_LIST"
     
 
 ''' Lightweight Data Structure to keep distribution of citations of the years '''

--- a/test_module.py
+++ b/test_module.py
@@ -6,6 +6,7 @@ from scholarly import scholarly, ProxyGenerator
 from scholarly.publication_parser import PublicationParser
 import random
 from fp.fp import FreeProxy
+import json
 
 
 class TestScholarly(unittest.TestCase):
@@ -247,6 +248,37 @@ class TestScholarly(unittest.TestCase):
         pub_parser = PublicationParser(None)
         author_id_list = pub_parser._get_author_id_list(author_html_partial)
         self.assertTrue(author_id_list[3] == 'TEndP-sAAAAJ')
+
+    def test_serialiazation(self):
+        """
+        Test that we can serialize the Author and Publication types
+
+        Note: JSON converts integer keys to strings, resulting in the years
+        in `cites_per_year` dictionary as `str` type instead of `int`.
+        To ensure consistency with the typing, use `object_hook` option
+        when loading to convert the keys to integers.
+        """
+        # Test that a filled Author with unfilled Publication
+        # is serializable.
+        def cpy_decoder(di):
+            """A utility function to convert the keys in `cites_per_year` to `int` type.
+
+              This ensures consistency with `CitesPerYear` typing.
+            """
+            if "cites_per_year" in di:
+                di["cites_per_year"] = {int(k): v for k,v in di["cites_per_year"].items()}
+            return di
+
+        author = scholarly.search_author_id('EmD_lTEAAAAJ', filled=True)
+        serialized = json.dumps(author)
+        author_loaded = json.loads(serialized, object_hook=cpy_decoder)
+        self.assertEqual(author, author_loaded)
+        # Test that a loaded publication is still fillable and serializable.
+        pub = author_loaded['publications'][0]
+        scholarly.fill(pub)
+        serialized = json.dumps(pub)
+        pub_loaded = json.loads(serialized, object_hook=cpy_decoder)
+        self.assertEqual(pub, pub_loaded)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR makes Author and Publication object serializable, which appears to be a popular request.
(see  #292, #201 , #195)

Enums and set types are not serializable by default. By inheriting from `int` and converting `set` to `list`, the `Author` and `Publication` data types can be serialized and stored on disk. This follows the suggestion in #292.

Minor caveat: Loading the serialized object using the `json` module converts the keys in `cites_per_year` dictionary into strings, while `scholarly` keeps them as `int`. This can be handled trivially by applications that use the serialized objects. The decoder function used in the unit test can be documented for ease, or make `cites_per_year` have `str` keys.
