### PR TITLE
Test that coauthors towards the end are fetched

### DIFF
--- a/test_module.py
+++ b/test_module.py
@@ -147,6 +147,7 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(author['name'], u'Steven A. Cholewiak, PhD')
         self.assertEqual(author['scholar_id'], u'4bahYMkAAAAJ')        
         self.assertGreaterEqual(len(author['coauthors']), 33)
+        self.assertTrue('I23YUh8AAAAJ' in [_coauth['scholar_id'] for _coauth in author['coauthors']])
         pub = scholarly.fill(author['publications'][2])
         self.assertEqual(pub['author_pub_id'],u'4bahYMkAAAAJ:LI9QrySNdTsC')
 


### PR DESCRIPTION
This should have been part of #322 but I had forgotten to push this commit. This makes testing for all coauthors more robust. Sorry for the noise.