### PR TITLE
Expose scholarly exceptions

### DIFF
--- a/scholarly/__init__.py
+++ b/scholarly/__init__.py
@@ -1,4 +1,5 @@
 from ._scholarly import _Scholarly
 from ._proxy_generator import ProxyGenerator
 from .data_types import Author, Publication
+from ._navigator import DOSException, MaxTriesExceededException
 scholarly = _Scholarly()


### PR DESCRIPTION
The library must make its special exceptions exposed to applications so they can be handled appropriately instead of a generic `Exception`. 