### PR TITLE
Assorted commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ scholarly is a module that allows you to retrieve author and publication informa
 
 ## Important Note
 
-This is version 1.1 of the `scholarly` library. There has been a major refactor in the way the library operates and it's code structure and it **will break** most existing code, based on the previous versions.
+This is version 1.3 of the `scholarly` library. There has been a major refactor in the way the library operates and it's code structure and it **will break** most existing code, based on the previous (v0.x) versions.
 
 ## Documentation
 

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -61,13 +61,16 @@ class _SearchScholarIterator(object):
         self._rows = self._soup.find_all('div', class_='gs_r gs_or gs_scl')
 
     def _get_total_results(self):
+        if self._soup.find("div", class_="gs_pda"):
+            return None
+
         for x in self._soup.find_all('div', class_='gs_ab_mdw'):
             # Accounting for different thousands separators: 
             # comma, dot, space, apostrophe
             match = re.match(pattern=r'(^|\s*About)\s*([0-9,\.\s’]+)', string=x.text)
             if match:
                 return int(re.sub(pattern=r'[,\.\s’]',repl='', string=match.group(2)))
-        return None
+        return 0
 
     # Iterator protocol
 

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -118,6 +118,8 @@ class PublicationParser(object):
         publication["num_citations"] = 0
         if citedby and not (citedby.text.isspace() or citedby.text == ''):
             publication["num_citations"] = int(citedby.text.strip())
+            publication["citedby_url"] = citedby["href"]
+            publication["cites_id"] = re.findall(_SCHOLARPUBRE, citedby["href"])[0].split(',')
 
         year = __data.find(class_='gsc_a_h')
         if (year and year.text

--- a/test_module.py
+++ b/test_module.py
@@ -207,9 +207,9 @@ class TestScholarly(unittest.TestCase):
 
     def test_search_pubs_total_results(self):
         """
-        As of February 4, 2021 there are 32 pubs that fit the search term:
+        As of September 16, 2021 there are 32 pubs that fit the search term:
         ["naive physics" stability "3d shape"], and 17'000 results that fit
-        the search term ["WIEN2k Blaha"].
+        the search term ["WIEN2k Blaha"] and none for ["sdfsdf+24r+asdfasdf"].
 
         Check that the total results for that search term equals 32.
         """
@@ -218,6 +218,9 @@ class TestScholarly(unittest.TestCase):
 
         pubs = scholarly.search_pubs('WIEN2k Blaha')
         self.assertGreaterEqual(pubs.total_results, 10000)
+
+        pubs = scholarly.search_pubs('sdfsdf+24r+asdfasdf')
+        self.assertEqual(pubs.total_results, 0)
 
     def test_search_pubs_filling_publication_contents(self):
         '''

--- a/test_module.py
+++ b/test_module.py
@@ -155,8 +155,9 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(author['scholar_id'], u'4bahYMkAAAAJ')        
         self.assertGreaterEqual(len(author['coauthors']), 33)
         self.assertTrue('I23YUh8AAAAJ' in [_coauth['scholar_id'] for _coauth in author['coauthors']])
-        pub = scholarly.fill(author['publications'][2])
-        self.assertEqual(pub['author_pub_id'],u'4bahYMkAAAAJ:LI9QrySNdTsC')
+        pub = author['publications'][2]
+        self.assertEqual(pub['author_pub_id'], u'4bahYMkAAAAJ:LI9QrySNdTsC')
+        self.assertTrue('5738786554683183717' in pub['cites_id'])
 
     def test_search_author_multiple_authors(self):
         """
@@ -190,6 +191,9 @@ class TestScholarly(unittest.TestCase):
                          u'Institut du radium, University of Paris')
         self.assertGreaterEqual(author['citedby'], 1963) # TODO: maybe change
         self.assertGreaterEqual(len(author['publications']), 179)
+        pub = author['publications'][1]
+        self.assertEqual(pub["citedby_url"],
+                         "https://scholar.google.com/scholar?oi=bibs&hl=en&cites=9976400141451962702")
 
     def test_search_pubs(self):
         """


### PR DESCRIPTION
This is a PR with three unrelated commits:

- Currently `cites_id` and `citedby_url` are filled only when filling a `Publication`. Although not blocked by `robots.txt`, this is still wasteful when they could be filled from the author's profile page directly if the author's publications are being filled.
- `_SearchScholarIterator` should have `total_results` set to 0 instead of `None` if no results are returned. The fix does set it to `None` in the rare cases when Google Scholar gives a suggestion for alternate queries. I can set it to 0 in those cases as well if desired.
- Updating version in README file

On a related note, what is the estimated time for the next release?