### PR TITLE
Get short coauthor list

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ scholarly is a module that allows you to retrieve author and publication informa
 
 ## Important Note
 
-This is version 1.3 of the `scholarly` library. There has been a major refactor in the way the library operates and it's code structure and it **will break** most existing code, based on the previous (v0.x) versions.
+This is version 1.4 of the `scholarly` library. There has been a major refactor in the way the library operates and it's code structure and it **will break** most existing code, based on the previous (v0.x) versions.
 
 ## Documentation
 

--- a/test_module.py
+++ b/test_module.py
@@ -21,8 +21,8 @@ class TestScholarly(unittest.TestCase):
             tor_sock_port = None
             tor_control_port = None
             tor_password = "scholarly_password"
-            # Tor uses the 9050 port as the default socks port 
-            # on windows 9150 for socks and 9151 for control 
+            # Tor uses the 9050 port as the default socks port
+            # on windows 9150 for socks and 9151 for control
             if sys.platform.startswith("linux") or sys.platform.startswith("darwin"):
                 tor_sock_port = 9050
                 tor_control_port = 9051
@@ -48,11 +48,11 @@ class TestScholarly(unittest.TestCase):
         elif self.connection_method == "freeproxy":
             proxy_generator.FreeProxies()
             scholarly.use_proxy(proxy_generator)
-        elif self.connection_method == "scraperapi":   
+        elif self.connection_method == "scraperapi":
             proxy_generator.ScraperAPI(os.getenv('SCRAPER_API_KEY'))
             scholarly.use_proxy(proxy_generator)
         else:
-            scholarly.use_proxy(None)      
+            scholarly.use_proxy(None)
 
     @unittest.skipUnless([_bin for path in sys.path if os.path.isdir(path) for _bin in os.listdir(path)
                           if _bin=='tor' or _bin=='tor.exe'], reason='Tor executable not found')
@@ -133,7 +133,7 @@ class TestScholarly(unittest.TestCase):
         """
         # Machine-learned epidemiology: real-time detection of foodborne illness at scale
         publication_id = 2244396665447968936
-        
+
         pubs = [p for p in scholarly.search_citedby(publication_id)]
         self.assertGreaterEqual(len(pubs), 11)
 
@@ -152,7 +152,7 @@ class TestScholarly(unittest.TestCase):
         self.assertGreaterEqual(len(authors), 1)
         author = scholarly.fill(authors[0])
         self.assertEqual(author['name'], u'Steven A. Cholewiak, PhD')
-        self.assertEqual(author['scholar_id'], u'4bahYMkAAAAJ')        
+        self.assertEqual(author['scholar_id'], u'4bahYMkAAAAJ')
         self.assertGreaterEqual(len(author['coauthors']), 33)
         self.assertTrue('I23YUh8AAAAJ' in [_coauth['scholar_id'] for _coauth in author['coauthors']])
         pub = author['publications'][2]


### PR DESCRIPTION
Applications that were filling coauthors simply because `sections` was left empty but not using them may crash in v1.4.0. While installing and placing the `geckodriver` executable in the PATH is the right solution, applications that don't really require coauthors should still be able to run without any changes without caring for incomplete list of coauthors. This patch modifies to behavior to warning the user that `geckodriver` is not in the PATH and hence the coauthor list is short instead of failing on them.

Fixes #331 and should preferably lead to v1.4.1 at the earliest.