### PR TITLE
Fix broken main branch

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -24,6 +24,6 @@ jobs:
 
     - name: Publish package to PyPI
       if: startsWith(github.event.ref, 'refs/tags')
-      uses: pypa/gh-action-pypi-publish@main
+      uses: pypa/gh-action-pypi-publish@master
       with:
         password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
Publishing to PyPI fails with `pypa/gh-action-pypi-publish@main`. Reverting it back to `master` and PR is intentionally to `main` directly.