### PR TITLE
Public access mandates

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -192,6 +192,7 @@ author information to fill, as follows:
 -  ``'counts'`` = number of citations per year;
 -  ``'coauthors'`` = co-authors;
 -  ``'publications'`` = publications;
+-  ``'public_access'`` = public_access;
 -  ``'[]'`` = all of the above (this is the default)
 
 .. code:: python

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -95,8 +95,10 @@ Search for an author by the id visible in the url of an Authors profile.
     {'affiliation': 'Professor of Vision Science, UC Berkeley',
      'email_domain': '@berkeley.edu',
      'filled': False,
+     'homepage': 'http://bankslab.berkeley.edu/',
      'interests': ['vision science', 'psychology', 'human factors', 'neuroscience'],
      'name': 'Martin Banks',
+     'organization': 11816294095661060495,
      'scholar_id': 'Smr99uEAAAAJ',
      'source': 'AUTHOR_PROFILE_PAGE'}
 
@@ -312,6 +314,7 @@ author information to fill, as follows:
      'filled': False,
      'hindex': 9,
      'hindex5y': 9,
+     'homepage': 'http://steven.cholewiak.com/',
      'i10index': 8,
      'i10index5y': 7,
      'interests': ['Depth Cues',
@@ -320,6 +323,7 @@ author information to fill, as follows:
                    'Naive Physics',
                    'Haptics'],
      'name': 'Steven A. Cholewiak, PhD',
+     'organization': 6518679690484165796,
      'scholar_id': '4bahYMkAAAAJ',
      'source': 'SEARCH_AUTHOR_SNIPPETS',
      'url_picture': 'https://scholar.google.com/citations?view_op=medium_photo&user=4bahYMkAAAAJ'}

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -102,6 +102,29 @@ Search for an author by the id visible in the url of an Authors profile.
      'scholar_id': 'Smr99uEAAAAJ',
      'source': 'AUTHOR_PROFILE_PAGE'}
 
+``search_author_by_organization``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Search for authors by organization ID.
+########################################################################
+
+.. code:: python
+
+    >>> scholarly.search_org('Princeton University')
+    [{'Organization': 'Princeton University', 'id': '4836318610601440500'}]
+
+    >>> search_query = scholarly.search_author_by_organization(4836318610601440500)
+    >>> author = next(search_query)
+    >>> scholarly.pprint(author)
+        {'affiliation': 'Princeton University (Emeritus)',
+         'citedby': 438891,
+         'email_domain': '@princeton.edu',
+         'filled': False,
+         'interests': ['Daniel Kahneman'],
+         'name': 'Daniel Kahneman',
+         'scholar_id': 'ImhakoAAAAAJ',
+         'source': 'SEARCH_AUTHOR_SNIPPETS',
+         'url_picture': 'https://scholar.google.com/citations?view_op=medium_photo&user=ImhakoAAAAAJ'}
+
 ``search_keyword``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -203,12 +203,17 @@ class _Scholarly:
 
         :param object: the Author or Publication object that needs to get filled
         :type object: Author or Publication
-        :param sections: the sections that the user wants filled for an Author object. This can be: ['basics', 'indices', 'counts', 'coauthors', 'publications']
+        :param sections: the sections that the user wants filled for an Author object. This can be: ['basics', 'indices', 'counts', 'coauthors', 'publications', 'public_access']
         :type sections: list
         :param sortby: if the object is an author, select the order of the citations in the author page. Either by 'citedby' or 'year'. Defaults to 'citedby'.
         :type sortby: string
         :param publication_limit: if the object is an author, select the max number of publications you want you want to fill for the author. Defaults to no limit.
         :type publication_limit: int
+
+        Note:  For Author objects, if 'public_access' is filled prior to 'publications',
+        only the total counts from the Public Access section of the author's profile page is filled.
+        If 'public_access' is filled along with 'publications' or afterwards for the first time,
+        the publication entries are also marked whether they satisfy public access mandates or not.
         """
 
         if object['container_type'] == "Author":
@@ -269,11 +274,13 @@ class _Scholarly:
             .. testoutput::
 
                 {'affiliation': 'Institut du radium, University of Paris',
+                 'citedby': 2208,
                  'filled': False,
                  'interests': [],
                  'name': 'Marie Skłodowska-Curie',
                  'scholar_id': 'EmD_lTEAAAAJ',
-                 'source': 'AUTHOR_PROFILE_PAGE'}
+                 'source': 'AUTHOR_PROFILE_PAGE',
+                 'url_picture': 'https://scholar.googleusercontent.com/citations?view_op=view_photo&user=EmD_lTEAAAAJ&citpid=3'}
         """
         return self.__nav.search_author_id(id, filled, sortby, publication_limit)
 

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -17,6 +17,7 @@ _KEYWORDSEARCH = '/citations?hl=en&view_op=search_authors&mauthors=label:{0}'
 _KEYWORDSEARCHBASE = '/citations?hl=en&view_op=search_authors&mauthors={}'
 _PUBSEARCH = '/scholar?hl=en&q={0}'
 _CITEDBYSEARCH = '/scholar?hl=en&cites={0}'
+_ORGSEARCH = "/citations?view_op=view_org&hl=en&org={0}"
 
 
 class _Scholarly:
@@ -447,6 +448,24 @@ class _Scholarly:
 
         url = _AUTHSEARCH.format(requests.utils.quote(name))
         return self.__nav.search_organization(url, fromauthor)
+
+    def search_author_by_organization(self, organization_id: int):
+        """
+        Search for authors in an organization and return a generator of Authors
+
+        ``organization_id`` can be found from the organization name using
+        ``search_org``. Alternatively, they can be found in the ``Author`` object.
+
+        The returned authors are typically in the decreasing order of total citations.
+        The authors must have a verified email address and set their affiliation
+        appropriately to appear on this list.
+
+        :param organization_id: unique integer id for each organization
+        :type organization_id: integer
+        """
+        url = _ORGSEARCH.format(organization_id)
+        return self.__nav.search_authors(url)
+
 
 def _construct_url(baseurl: str, patents: bool = True,
                     citations: bool = True, year_low: int = None,

--- a/scholarly/author_parser.py
+++ b/scholarly/author_parser.py
@@ -77,7 +77,7 @@ class AuthorParser:
         author['name'] = soup.find('div', id='gsc_prf_in').text
         if author['source'] == AuthorSource.AUTHOR_PROFILE_PAGE:
             res = soup.find('img', id='gsc_prf_pup-img')
-            if res != None:
+            if res is not None:
                 if "avatar_scholar" not in res['src']:
                     author['url_picture'] = res['src']
         elif author['source'] == AuthorSource.CO_AUTHORS_LIST:
@@ -285,7 +285,8 @@ class AuthorParser:
 
             search_query = scholarly.search_author('Steven A Cholewiak')
             author = next(search_query)
-            scholarly.pprint(author.fill(sections=['basic', 'citation_indices', 'co-authors']))
+            author = scholarly.fill(author, sections=['basics', 'citations', 'coauthors'])
+            scholarly.pprint(author)
 
         :Output::
 

--- a/scholarly/author_parser.py
+++ b/scholarly/author_parser.py
@@ -21,6 +21,7 @@ class AuthorParser:
         self._sections = {'basics',
                           'indices',
                           'counts',
+                          'public_access',
                           'coauthors',
                           'publications'}
 
@@ -124,6 +125,15 @@ class AuthorParser:
                  for c in soup.find_all('span', class_='gsc_g_al')]
         author['cites_per_year'] = dict(zip(years, cites))
 
+    def _fill_public_access(self, soup, author):
+        author["public_access"] = dict.fromkeys(("available", "not_available"), 0)
+        available = soup.find('div', class_='gsc_rsb_m_a')
+        not_available = soup.find('div', class_='gsc_rsb_m_na')
+        if available:
+            author["public_access"]["available"] = int(available.text.split(" ")[0])
+        if not_available:
+            author["public_access"]["not_available"] = int(not_available.text.split(" ")[0])
+
     def _fill_publications(self, soup, author, publication_limit: int = 0, sortby_str: str = ''):
         author['publications'] = list()
         pubstart = 0
@@ -222,10 +232,11 @@ class AuthorParser:
             * ``basics``: fills name, affiliation, and interests;
             * ``citations``: fills h-index, i10-index, and 5-year analogues;
             * ``counts``: fills number of citations per year;
+            * ``public_access``: fills number of articles with public access mandates;
             * ``coauthors``: fills co-authors;
             * ``publications``: fills publications;
             * ``[]``: fills all of the above
-        :type sections: ['basics','citations','counts','coauthors','publications',[]] list, optional
+        :type sections: ['basics','citations','counts','public_access','coauthors','publications',[]] list, optional
         :param sortby: Select the order of the citations in the author page. Either by 'citedby' or 'year'. Defaults to 'citedby'.
         :type sortby: string
         :param publication_limit: Select the max number of publications you want you want to fill for the author. Defaults to no limit.

--- a/scholarly/author_parser.py
+++ b/scholarly/author_parser.py
@@ -83,7 +83,11 @@ class AuthorParser:
                 picture = _HOST.format(picture)
             author['url_picture'] = picture
 
-        author['affiliation'] = soup.find('div', class_='gsc_prf_il').text
+        affiliation = soup.find('div', class_='gsc_prf_il')
+        author['affiliation'] = affiliation.text
+        affiliation_link = affiliation.find('a')
+        if affiliation_link:
+            author['organization'] = int(affiliation_link.get('href').split("org=")[-1])
         author['interests'] = [i.text.strip() for i in
                           soup.find_all('a', class_='gsc_prf_inta')]
         email = soup.find('div', id="gsc_prf_ivh", class_="gsc_prf_il")

--- a/scholarly/author_parser.py
+++ b/scholarly/author_parser.py
@@ -77,18 +77,23 @@ class AuthorParser:
             if res != None:
                 if "avatar_scholar" not in res['src']:
                     author['url_picture'] = res['src']
-        author['affiliation'] = soup.find('div', class_='gsc_prf_il').text
-        author['interests'] = [i.text.strip() for i in
-                          soup.find_all('a', class_='gsc_prf_inta')]
-        if author['source'] == AuthorSource.AUTHOR_PROFILE_PAGE:
-            email = soup.find('div', id="gsc_prf_ivh", class_="gsc_prf_il")
-            if email.text != "No verified email":
-                author['email_domain'] = '@'+email.text.split(" ")[3]
-        if author['source'] == AuthorSource.CO_AUTHORS_LIST:
+        elif author['source'] == AuthorSource.CO_AUTHORS_LIST:
             picture = soup.find('img', id="gsc_prf_pup-img").get('src')
             if "avatar_scholar" in picture:
                 picture = _HOST.format(picture)
             author['url_picture'] = picture
+
+        author['affiliation'] = soup.find('div', class_='gsc_prf_il').text
+        author['interests'] = [i.text.strip() for i in
+                          soup.find_all('a', class_='gsc_prf_inta')]
+        email = soup.find('div', id="gsc_prf_ivh", class_="gsc_prf_il")
+        if author['source'] == AuthorSource.AUTHOR_PROFILE_PAGE:
+            if email.text != "No verified email":
+                author['email_domain'] = '@'+email.text.split(" ")[3]
+        homepage = email.find('a', class_="gsc_prf_ila")
+        if homepage:
+            author['homepage'] = homepage.get('href')
+
         index = soup.find_all('td', class_='gsc_rsb_std')
         if index:
             author['citedby'] = int(index[0].text)
@@ -348,6 +353,7 @@ class AuthorParser:
                             'scholar_id': 'nHx9IgYAAAAJ',
                             'source': 'CO_AUTHORS_LIST'}],
              'email_domain': '@berkeley.edu',
+             'homepage': 'http://steven.cholewiak.com/',
              'filled': False,
              'hindex': 9,
              'hindex5y': 9,

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -206,6 +206,7 @@ class Author(TypedDict, total=False):
     scholar_id: str
     name: str
     affiliation: str
+    organization: int
     email_domain: str
     url_picture: str
     homepage: str

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -154,6 +154,7 @@ class Publication(TypedDict, total=False):
                           of multiple publications, and therefore may have multiple "citedby_id"
                           values.
                           (source: AUTHOR_PUBLICATION_ENTRY)
+    :param public_access: Boolean corresponding to whether the article is available or not in accordance with public access mandates.
     :param url_related_articles: the url containing link for related articles of a publication (needs fill() for AUTHOR_PUBLICATION_ENTRIES)
     :param url_add_sclib: (source: PUBLICATION_SEARCH_SNIPPET)
     :param url_scholarbib: the url containing links for 
@@ -172,6 +173,7 @@ class Publication(TypedDict, total=False):
     citedby_url: str
     cites_per_year: CitesPerYear
     author_pub_id: str
+    public_access: bool
     eprint_url: str
     pub_url: str
     url_add_sclib: str
@@ -189,6 +191,7 @@ class Author(TypedDict, total=False):
     :param scholar_id: The id of the author on Google Scholar
     :param name: The name of the author
     :param affiliation: The affiliation of the author
+    :param organization: A unique ID of the organization (source: AUTHOR_PROFILE_PAGE)
     :param email_domain: The email domain of the author (source: SEARCH_AUTHOR_SNIPPETS, AUTHOR_PROFILE_PAGE)
     :param url_picture: The URL for the picture of the author
     :param homepage: URL of the homepage of the author

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -180,12 +180,13 @@ class Author(TypedDict, total=False):
     """
     :class:`Author <Author>` object used to represent an author entry on Google Scholar.
            (When source is not specified, the field is present in all sources)
-    
+
     :param scholar_id: The id of the author on Google Scholar
     :param name: The name of the author
     :param affiliation: The affiliation of the author
     :param email_domain: The email domain of the author (source: SEARCH_AUTHOR_SNIPPETS, AUTHOR_PROFILE_PAGE)
     :param url_picture: The URL for the picture of the author
+    :param homepage: URL of the homepage of the author
     :param citedby: The number of citations to all publications. (source: SEARCH_AUTHOR_SNIPPETS)
     :param filled: The list of sections filled out of the total set of sections that can be filled
     :param interests: Fields of interest of this Author (sources: SEARCH_AUTHOR_SNIPPETS, AUTHOR_PROFILE_PAGE)
@@ -199,7 +200,7 @@ class Author(TypedDict, total=False):
     :param coauthors: A list of coauthors (list of Author objects) (source: SEARCH_AUTHOR_SNIPPETS)
     :param container_type: Used from the source code to identify if this container object
                            is an Author or a Publication object.
-    :param source: The place where the author information are derived 
+    :param source: The place where the author information are derived
     """
 
     scholar_id: str
@@ -207,6 +208,7 @@ class Author(TypedDict, total=False):
     affiliation: str
     email_domain: str
     url_picture: str
+    homepage: str
     citedby: int
     filled: List[str]
     interests: List[str]

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -81,6 +81,11 @@ class AuthorSource(str, Enum):
 CitesPerYear = Dict[int, int]
 
 
+''' Lightweight Data Structure to hold the numbers articles available or
+    not available publicly according to funding mandates
+'''
+PublicAccess = TypedDict('PublicAccess', {"available": int, "not_available": int})
+
 class BibEntry(TypedDict, total=False):
     """
     :class:`BibEntry <BibEntry>` The bibliographic entry for a publication
@@ -196,6 +201,7 @@ class Author(TypedDict, total=False):
     :param i10index: This is the number of publications with at least 10 citations.  (source: SEARCH_AUTHOR_SNIPPETS)
     :param i10index5y: The number of publications that have received at least 10 new citations in the last 5 years. (source: SEARCH_AUTHOR_SNIPPETS)
     :param cites_per_year: Breakdown of the number of citations to all publications over the years (source: SEARCH_AUTHOR_SNIPPETS)
+    :param public_access: Number of articles that are available and not available in accordance with public access mandates. (source: SEARCH_AUTHOR_SNIPPETS, AUTHOR_PROFILE_PAGE)
     :param publications: A list of publications objects. (source: SEARCH_AUTHOR_SNIPPETS)
     :param coauthors: A list of coauthors (list of Author objects) (source: SEARCH_AUTHOR_SNIPPETS)
     :param container_type: Used from the source code to identify if this container object
@@ -219,6 +225,7 @@ class Author(TypedDict, total=False):
     i10index: int
     i10index5y: int
     cites_per_year: CitesPerYear
+    public_access: PublicAccess
     publications: List[Publication]
     coauthors: List # List of authors. No self dict functionality available
     container_type: str

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -4,78 +4,78 @@ from enum import Enum
 from typing import List, Dict
 
 if sys.version_info >= (3, 8):
-    from typing import TypedDict 
+    from typing import TypedDict
 else:
     from typing_extensions import TypedDict
 
 
 class PublicationSource(str, Enum):
     '''
-    Defines the source of the publication. In general, a publication 
+    Defines the source of the publication. In general, a publication
     on Google Scholar has two forms:
     * Appearing as a PUBLICATION SNIPPET and
     * Appearing as a paper in an AUTHOR PAGE
-    
+
     ------------
-    
-    "PUBLICATION SEARCH SNIPPET". 
-    This form captures the publication  when it appears as a "snippet" in 
+
+    "PUBLICATION SEARCH SNIPPET".
+    This form captures the publication  when it appears as a "snippet" in
     the context of the resuls of a publication search. For example:
-    
+
     Publication search: https://scholar.google.com/scholar?hl=en&q=adaptive+fraud+detection&btnG=&as_sdt=0%2C33
-    
+
     The entries appear under the <div class = "gs_r gs_or gs_scl"> tags
     Each entry has a data-cid attribute (e.g., data-cid="pthm1bWT96oJ")
-    
-    The same type of results will also appear when someome searches 
+
+    The same type of results will also appear when someome searches
     using the "cited by", "related articles", and "all XX versions" links
     that appear under the publication snippet.
-    
+
     "Cited By" link: https://scholar.google.com/scholar?cites=12319477714873931942&as_sdt=5,33&sciodt=0,33&hl=en
-    
+
     "Related Articles" link: https://scholar.google.com/scholar?q=related:pthm1bWT96oJ:scholar.google.com/&scioq=adaptive+fraud+detection&hl=en&as_sdt=0,33
-    
+
     "All versions" link: https://scholar.google.com/scholar?cluster=12319477714873931942&hl=en&as_sdt=0,33
-    
+
     The snippet version of these publications contain the information that appears in the results.
     Often, the snippet version will miss authors, will have an abbreviated name for the venue, and so on.
-    
-    We can fill these snippets by clicking on the "Cite" button" and get back the MLA/APA/Chicago/... 
+
+    We can fill these snippets by clicking on the "Cite" button" and get back the MLA/APA/Chicago/...
     citations forms, PLUS links for BibTeX, EndNote, RefMan, and RefWorks.
-    
+
     ------------
     "AUTHOR PUBLICATION ENTRY"
-    
-    We also have publications that appear in the "author pages" of Google Scholar. 
-    These publications are often a set of publications "merged" together. 
-    
+
+    We also have publications that appear in the "author pages" of Google Scholar.
+    These publications are often a set of publications "merged" together.
+
     The snippet version of these publications conains the title of the publication,
     a subset of the authors, the (sometimes truncated) venue, and the year of the publication
     and the number of papers that cite the publication.
-    
+
     The snippet entries appear under the <tr class="gsc_a_tr"> entries in the main page of the author.
-    
+
     To fill in the publication, we open the "detailed view" of the paper
-    
+
     Detailed view page: https://scholar.google.com/citations?view_op=view_citation&hl=en&citation_for_view=-Km63D4AAAAJ:d1gkVwhDpl0C
     '''
     PUBLICATION_SEARCH_SNIPPET = "PUBLICATION_SEARCH_SNIPPET"
     AUTHOR_PUBLICATION_ENTRY = "AUTHOR_PUBLICATION_ENTRY"
-    
+
 class AuthorSource(str, Enum):
     '''
     Defines the source of the HTML that will be parsed.
-    
+
     Author page: https://scholar.google.com/citations?hl=en&user=yxUduqMAAAAJ
-    
+
     Search authors: https://scholar.google.com/citations?view_op=search_authors&hl=en&mauthors=jordan&btnG=
-    
+
     Coauthors: From the list of co-authors from an Author page
     '''
     AUTHOR_PROFILE_PAGE = "AUTHOR_PROFILE_PAGE"
     SEARCH_AUTHOR_SNIPPETS = "SEARCH_AUTHOR_SNIPPETS"
     CO_AUTHORS_LIST = "CO_AUTHORS_LIST"
-    
+
 
 ''' Lightweight Data Structure to keep distribution of citations of the years '''
 CitesPerYear = Dict[int, int]
@@ -133,15 +133,15 @@ class Publication(TypedDict, total=False):
                        16766804411681372720 then:
                        https://scholar.google.com/scholar?cites=<cites_id>&hl=en
                        If the publication comes from a "merged" list of papers from an authors page,
-                       the "citedby_id" will be a comma-separated list of values. 
+                       the "citedby_id" will be a comma-separated list of values.
                        It is also used to return the "cluster" of all the different versions of the paper.
                        https://scholar.google.com/scholar?cluster=16766804411681372720&hl=en
                        (source: AUTHOR_PUBLICATION_ENTRY)
     :param citedby_url: This corresponds to a "single" publication on Google Scholar. Used in the web search
-                       request to return all the papers that cite the publication. 
+                       request to return all the papers that cite the publication.
                        https://scholar.google.com/scholar?cites=16766804411681372720hl=en
-                       If the publication comes from a "merged" list of papers from an authors page, 
-                       the "citedby_url" will be a comma-separated list of values. 
+                       If the publication comes from a "merged" list of papers from an authors page,
+                       the "citedby_url" will be a comma-separated list of values.
                        It is also used to return the "cluster" of all the different versions of the paper.
                        https://scholar.google.com/scholar?cluster=16766804411681372720&hl=en
     :param cites_per_year: a dictionay containing the number of citations per year for this Publication
@@ -157,7 +157,7 @@ class Publication(TypedDict, total=False):
     :param public_access: Boolean corresponding to whether the article is available or not in accordance with public access mandates.
     :param url_related_articles: the url containing link for related articles of a publication (needs fill() for AUTHOR_PUBLICATION_ENTRIES)
     :param url_add_sclib: (source: PUBLICATION_SEARCH_SNIPPET)
-    :param url_scholarbib: the url containing links for 
+    :param url_scholarbib: the url containing links for
                            the BibTeX entry, EndNote, RefMan and RefWorks (source: PUBLICATION_SEARCH_SNIPPET)
     :param filled: whether the publication is fully filled or not
     :param source: The source of the publication entry

--- a/test_module.py
+++ b/test_module.py
@@ -162,6 +162,7 @@ class TestScholarly(unittest.TestCase):
             self.assertTrue('I23YUh8AAAAJ' in [_coauth['scholar_id'] for _coauth in author['coauthors']])
         else:
             self.assertEqual(len(author['coauthors']), 20)
+        self.assertEqual(author['homepage'], "http://steven.cholewiak.com/")
         pub = author['publications'][2]
         self.assertEqual(pub['author_pub_id'], u'4bahYMkAAAAJ:LI9QrySNdTsC')
         self.assertTrue('5738786554683183717' in pub['cites_id'])

--- a/test_module.py
+++ b/test_module.py
@@ -333,6 +333,18 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(pub['bib']['title'],
                          u'Evaluation of toxicity of Dichlorvos (Nuvan) to fresh water fish Anabas testudineus and possible modulation by crude aqueous extract of Andrographis paniculata: A preliminary investigation')
 
+    def test_author_organization(self):
+        """
+        """
+        organization = 4836318610601440500  # Princeton University
+        search_query = scholarly.search_author_by_organization(organization)
+        author = next(search_query)
+        self.assertEqual(author['scholar_id'], "ImhakoAAAAAJ")
+        self.assertEqual(author['name'], "Daniel Kahneman")
+        self.assertEqual(author['email_domain'], "@princeton.edu")
+        self.assertEqual(author['affiliation'], "Princeton University (Emeritus)")
+        self.assertGreaterEqual(author['citedby'], 438891)
+
     def test_public_access(self):
         """
         Test that we obtain public access information

--- a/test_module.py
+++ b/test_module.py
@@ -333,6 +333,27 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(pub['bib']['title'],
                          u'Evaluation of toxicity of Dichlorvos (Nuvan) to fresh water fish Anabas testudineus and possible modulation by crude aqueous extract of Andrographis paniculata: A preliminary investigation')
 
+    def test_public_access(self):
+        """
+        Test that we obtain public access information
+
+        We check two cases: 1) when number of public access mandates exceeds
+        100, thus requiring fetching information from a second page and 2) fill
+        public access counts without fetching publications.
+        """
+        author = scholarly.search_author_id("7x48vOkAAAAJ")
+        scholarly.fill(author, sections=['basics', 'public_access', 'publications'])
+        self.assertGreaterEqual(author["public_access"]["available"], 110)
+        self.assertEqual(author["public_access"]["available"],
+                         sum(pub.get("public_access", None) is True for pub in author["publications"]))
+        self.assertEqual(author["public_access"]["not_available"],
+                         sum(pub.get("public_access", None) is False for pub in author["publications"]))
+
+        author = next(scholarly.search_author("Daniel Kahneman"))
+        scholarly.fill(author, sections=["basics", "indices", "public_access"])
+        self.assertEqual(author["scholar_id"], "ImhakoAAAAAJ")
+        self.assertGreaterEqual(author["public_access"]["available"], 6)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_module.py
+++ b/test_module.py
@@ -164,6 +164,7 @@ class TestScholarly(unittest.TestCase):
             self.assertEqual(len(author['coauthors']), 20)
         self.assertEqual(author['homepage'], "http://steven.cholewiak.com/")
         self.assertEqual(author['organization'], 6518679690484165796)
+        self.assertGreaterEqual(author['public_access']['available'], 10)
         pub = author['publications'][2]
         self.assertEqual(pub['author_pub_id'], u'4bahYMkAAAAJ:LI9QrySNdTsC')
         self.assertTrue('5738786554683183717' in pub['cites_id'])
@@ -198,6 +199,8 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(author['name'], u'Marie Skłodowska-Curie')
         self.assertEqual(author['affiliation'],
                          u'Institut du radium, University of Paris')
+        self.assertEqual(author['public_access']['available'], 0)
+        self.assertEqual(author['public_access']['not_available'], 0)
         self.assertGreaterEqual(author['citedby'], 1963) # TODO: maybe change
         self.assertGreaterEqual(len(author['publications']), 179)
         pub = author['publications'][1]

--- a/test_module.py
+++ b/test_module.py
@@ -163,6 +163,7 @@ class TestScholarly(unittest.TestCase):
         else:
             self.assertEqual(len(author['coauthors']), 20)
         self.assertEqual(author['homepage'], "http://steven.cholewiak.com/")
+        self.assertEqual(author['organization'], 6518679690484165796)
         pub = author['publications'][2]
         self.assertEqual(pub['author_pub_id'], u'4bahYMkAAAAJ:LI9QrySNdTsC')
         self.assertTrue('5738786554683183717' in pub['cites_id'])

--- a/test_module.py
+++ b/test_module.py
@@ -165,6 +165,10 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(author['homepage'], "http://steven.cholewiak.com/")
         self.assertEqual(author['organization'], 6518679690484165796)
         self.assertGreaterEqual(author['public_access']['available'], 10)
+        self.assertEqual(author['public_access']['available'],
+                         sum(pub.get('public_access', None) is True for pub in author['publications']))
+        self.assertEqual(author['public_access']['not_available'],
+                         sum(pub.get('public_access', None) is False for pub in author['publications']))
         pub = author['publications'][2]
         self.assertEqual(pub['author_pub_id'], u'4bahYMkAAAAJ:LI9QrySNdTsC')
         self.assertTrue('5738786554683183717' in pub['cites_id'])


### PR DESCRIPTION
Fixes #335, #338 and #372

The PR achieves three new features:

- It fetches the URL to the homepage from an author's profile
- Fetches an unique organization ID from the author's profile
- Fills in  the public access information, and optionally marks which articles are available according to the funding mandates and which do not.

The new code has almost 100% test coverage. 

