### PR TITLE
Improve FreeProxies

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -50,7 +50,7 @@ jobs:
           SCRAPER_API_KEY: ${{ secrets.SCRAPER_API_KEY }}
         run: |
           curl --data-binary @.github/.codecov.yml https://codecov.io/validate | head -n 1
-          coverage run -m unittest -v test_module.py
+          coverage run -m unittest -v test_module.TestScholarly
           coverage xml
       - name: Upload code coverage
         uses: codecov/codecov-action@v2

--- a/scholarly/__init__.py
+++ b/scholarly/__init__.py
@@ -1,5 +1,4 @@
 from ._scholarly import _Scholarly
-from ._proxy_generator import ProxyGenerator
 from .data_types import Author, Publication
-from ._navigator import DOSException, MaxTriesExceededException
+from ._proxy_generator import ProxyGenerator, DOSException, MaxTriesExceededException
 scholarly = _Scholarly()

--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from ._proxy_generator import ProxyGenerator
+from ._proxy_generator import ProxyGenerator, MaxTriesExceededException, DOSException
 
 from typing import Callable
 from bs4 import BeautifulSoup
@@ -31,11 +31,6 @@ from .author_parser import AuthorParser
 from .publication_parser import PublicationParser
 from .data_types import Author, PublicationSource
 
-class DOSException(Exception):
-    """DOS attack was detected."""
-
-class MaxTriesExceededException(Exception):
-    """Maximum number of tries by scholarly reached"""
 
 class Singleton(type):
     _instances = {}

--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -182,7 +182,7 @@ class Navigator(object, metaclass=Singleton):
                 self.logger.info("Retrying with a new session.")
 
             tries += 1
-            session, timeout = pm.get_next_proxy(num_tries = tries, old_timeout = timeout)
+            session, timeout = pm.get_next_proxy(num_tries = tries, old_timeout = timeout, old_proxy=session.proxies.get('http', None))
 
         # If secondary proxy does not work, try again primary proxy.
         if not premium:

--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -29,7 +29,7 @@ from fake_useragent import UserAgent
 from .publication_parser import _SearchScholarIterator
 from .author_parser import AuthorParser
 from .publication_parser import PublicationParser
-from .data_types import Author, PublicationSource
+from .data_types import Author, PublicationSource, ProxyMode
 
 
 class Singleton(type):
@@ -117,7 +117,7 @@ class Navigator(object, metaclass=Singleton):
             pm = self.pm1
             session = self._session1
             premium = True
-        if pm._use_scraperapi:
+        if pm.proxy_mode is ProxyMode.SCRAPERAPI:
             self.set_timeout(60)
         timeout=self._TIMEOUT
         while tries < self._max_retries:
@@ -142,7 +142,7 @@ class Navigator(object, metaclass=Singleton):
                         if not self.got_403:
                             self.logger.info("Retrying immediately with another session.")
                         else:
-                            if not pm._use_luminati:
+                            if pm.proxy_mode not in (ProxyMode.LUMINATI, ProxyMode.SCRAPERAPI):
                                 w = random.uniform(60, 2*60)
                                 self.logger.info("Will retry after {} seconds (with another session).".format(w))
                                 time.sleep(w)

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -21,9 +21,13 @@ from stem.control import Controller
 from fake_useragent import UserAgent
 from dotenv import load_dotenv, find_dotenv
 
+
 class DOSException(Exception):
     """DOS attack was detected."""
 
+
+class MaxTriesExceededException(Exception):
+    """Maximum number of tries by scholarly reached"""
 
 class Singleton(type):
     _instances = {}

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -343,9 +343,8 @@ class ProxyGenerator(object):
             # Redirect webdriver through proxy
             webdriver.DesiredCapabilities.FIREFOX['proxy'] = {
                 "httpProxy": self._session.proxies['http'],
-                "ftpProxy": self._session.proxies['http'],
                 "sslProxy": self._session.proxies['https'],
-                "proxyType":"MANUAL",
+                "proxyType": "MANUAL",
             }
 
         self._webdriver = webdriver.Firefox()

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -161,8 +161,11 @@ class ProxyGenerator(object):
             except (TimeoutException, TimeoutError):
                 time.sleep(self._TIMEOUT)
             except Exception as e:
-                self.logger.warning("Exception while testing proxy: %s", e)
-                if ('lum' in proxies['http']) or ('scraperapi' in proxies['http']):
+                # Failure is common and expected with free proxy.
+                # Do not log at warning level and annoy users.
+                level = logging.DEBUG if self.proxy_mode is ProxyMode.FREE_PROXIES else logging.WARNING
+                self.logger.log(level, "Exception while testing proxy: %s", e)
+                if self.proxy_mode in (ProxyMode.LUMINATI, ProxyMode.SCRAPERAPI):
                     self.logger.warning("Double check your credentials and try increasing the timeout")
 
             return False

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -66,7 +66,7 @@ class ProxyGenerator(object):
     def get_session(self):
         return self._session
 
-    def Luminati(self, usr , passwd, proxy_port, skip_checking_proxy=False):
+    def Luminati(self, usr, passwd, proxy_port, skip_checking_proxy=False):
         """ Setups a luminati proxy without refreshing capabilities.
 
         Note: ``skip_checking_proxy`` is meant to be set to `True` only in
@@ -86,10 +86,10 @@ class ProxyGenerator(object):
         :rtype: {bool}
 
         :Example::
-            pg = ProxyGenerator()
-            success = pg.Luminati(usr = foo, passwd = bar, port = 1200)
+            >>> pg = ProxyGenerator()
+            >>> success = pg.Luminati(usr = foo, passwd = bar, port = 1200)
         """
-        if (usr != None and passwd != None and proxy_port != None):
+        if (usr is not None and passwd is not None and proxy_port is not None):
             username = usr
             password = passwd
             port = proxy_port
@@ -101,7 +101,7 @@ class ProxyGenerator(object):
         proxy_works = self._use_proxy(http=proxy, https=proxy, skip_checking_proxy=skip_checking_proxy)
         return proxy_works
 
-    def SingleProxy(self, http = None, https = None, skip_checking_proxy=False):
+    def SingleProxy(self, http=None, https=None, skip_checking_proxy=False):
         """
         Use proxy of your choice
 
@@ -110,18 +110,18 @@ class ProxyGenerator(object):
         value of `False`.
 
         :param http: http proxy address
-        type http: string
+        :type http: string
         :param https: https proxy adress
         :type https: string
-        :param skip_checking_proxy: skip checking if the proxy works,
-                                    optional by default False
+        :param skip_checking_proxy: skip checking if the proxy works, optional by default False
         :type skip_checking_proxy: bool
         :returns: whether or not the proxy was set up successfully
         :rtype: {bool}
 
         :Example::
-            pg = ProxyGenerator()
-            success = pg.SingleProxy(http = <http proxy adress>, https = <https proxy adress>)
+
+            >>> pg = ProxyGenerator()
+            >>> success = pg.SingleProxy(http = <http proxy adress>, https = <https proxy adress>)
         """
         proxy_works = self._use_proxy(http=http, https=https, skip_checking_proxy=skip_checking_proxy)
         return proxy_works
@@ -147,7 +147,6 @@ class ProxyGenerator(object):
             except (TimeoutException, TimeoutError):
                 time.sleep(self._TIMEOUT)
             except Exception as e:
-                # import pdb; pdb.set_trace()
                 self.logger.warning("Exception while testing proxy: %s", e)
                 if ('lum' in proxies['http']) or ('scraperapi' in proxies['http']):
                     self.logger.warning("Double check your credentials and try increasing the timeout")
@@ -482,10 +481,9 @@ class ProxyGenerator(object):
         :rtype: {bool}
 
         :Example::
-            pg = ProxyGenerator()
-            success = pg.FreeProxies()
+            >>> pg = ProxyGenerator()
+            >>> success = pg.FreeProxies()
         """
-        # import pdb; pdb.set_trace()
         self._fp_gen = self._fp_coroutine(timeout=timeout, wait_time=wait_time)
         self._proxy_gen = self._fp_gen.send
         proxy = self._proxy_gen(None)  # prime the generator
@@ -520,8 +518,8 @@ class ProxyGenerator(object):
         value of `False`.
 
         :Example::
-            pg = ProxyGenerator()
-            success = pg.ScraperAPI(API_KEY)
+            >>> pg = ProxyGenerator()
+            >>> success = pg.ScraperAPI(API_KEY)
 
         :param API_KEY: ScraperAPI API Key value.
         :type API_KEY: string
@@ -573,7 +571,7 @@ class ProxyGenerator(object):
 
         return False
 
-    def has_proxy(self)-> bool:
+    def has_proxy(self) -> bool:
         return self._proxy_gen or self._can_refresh_tor
 
     def _set_proxy_generator(self, gen: Callable[..., str]) -> bool:
@@ -589,7 +587,6 @@ class ProxyGenerator(object):
             time.sleep(5) # wait for the refresh to happen
             new_timeout = self._TIMEOUT # Reset timeout to default
         elif self._proxy_gen:
-            # import pdb; pdb.set_trace()
             if (num_tries):
                 self.logger.info(f"Try #{num_tries} failed. Switching proxy.") # TODO: add tries
             # Try to get another proxy

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -62,6 +62,7 @@ class PublicationSource(str, Enum):
     PUBLICATION_SEARCH_SNIPPET = "PUBLICATION_SEARCH_SNIPPET"
     AUTHOR_PUBLICATION_ENTRY = "AUTHOR_PUBLICATION_ENTRY"
 
+
 class AuthorSource(str, Enum):
     '''
     Defines the source of the HTML that will be parsed.
@@ -77,6 +78,19 @@ class AuthorSource(str, Enum):
     CO_AUTHORS_LIST = "CO_AUTHORS_LIST"
 
 
+class ProxyMode(str, Enum):
+    """
+    Defines the different types supported.
+    """
+    FREE_PROXIES = "FREE_PROXIES"
+    SCRAPERAPI = "SCRAPERAPI"
+    LUMINATI = "LUMINATI"
+    SINGLEPROXY = "SINGLEPROXY"
+    # Deprecated:
+    TOR_EXTERNAL = "TOR_EXTERNAL"
+    TOR_INTERNAL = "TOR_INTERNAL"
+
+
 ''' Lightweight Data Structure to keep distribution of citations of the years '''
 CitesPerYear = Dict[int, int]
 
@@ -85,6 +99,7 @@ CitesPerYear = Dict[int, int]
     not available publicly according to funding mandates
 '''
 PublicAccess = TypedDict('PublicAccess', {"available": int, "not_available": int})
+
 
 class BibEntry(TypedDict, total=False):
     """

--- a/test_module.py
+++ b/test_module.py
@@ -1,11 +1,9 @@
 import unittest
-import argparse
 import os
 import sys
 from scholarly import scholarly, ProxyGenerator
 from scholarly.publication_parser import PublicationParser
 import random
-from fp.fp import FreeProxy
 import json
 
 
@@ -117,7 +115,7 @@ class TestScholarly(unittest.TestCase):
             scholarly.set_retries(10)
             proxy_generator.Luminati(usr=os.getenv("USERNAME"),
                                      passwd=os.getenv("PASSWORD"),
-                                     proxy_port = os.getenv("PORT"))
+                                     proxy_port=os.getenv("PORT"))
 
         elif cls.connection_method == "freeproxy":
             # Use different instances for primary and secondary
@@ -155,7 +153,6 @@ class TestScholarly(unittest.TestCase):
         """
         pubs = [p for p in scholarly.search_pubs('')]
         self.assertIs(len(pubs), 0)
-
 
     def test_search_pubs_citedby(self):
         """

--- a/test_module.py
+++ b/test_module.py
@@ -57,6 +57,12 @@ class TestScholarly(unittest.TestCase):
         else:
             scholarly.use_proxy(None)
 
+    def tearDown(self):
+        return
+        if self.connection_method == "freeproxy":
+            scholarly._Scholarly__nav.pm1._fp_gen.close()
+        scholarly._Scholarly__nav.pm2._fp_gen.close()
+
     @unittest.skipUnless([_bin for path in sys.path if os.path.isdir(path) for _bin in os.listdir(path)
                           if _bin=='tor' or _bin=='tor.exe'], reason='Tor executable not found')
     def test_tor_launch_own_process(self):

--- a/test_module.py
+++ b/test_module.py
@@ -20,6 +20,7 @@ class TestLuminati(unittest.TestCase):
                                            passwd=os.getenv("PASSWORD"),
                                            proxy_port=os.getenv("PORT"))
         self.assertTrue(success)
+        self.assertEqual(proxy_generator.proxy_mode, "LUMINATI")
 
 
 class TestScraperAPI(unittest.TestCase):
@@ -33,6 +34,7 @@ class TestScraperAPI(unittest.TestCase):
         proxy_generator = ProxyGenerator()
         success = proxy_generator.ScraperAPI(os.getenv('SCRAPER_API_KEY'))
         self.assertTrue(success)
+        self.assertEqual(proxy_generator.proxy_mode, "SCRAPERAPI")
 
 
 class TestTorInternal(unittest.TestCase):

--- a/test_module.py
+++ b/test_module.py
@@ -199,12 +199,12 @@ class TestScholarly(unittest.TestCase):
         author = scholarly.fill(authors[0])
         self.assertEqual(author['name'], u'Steven A. Cholewiak, PhD')
         self.assertEqual(author['scholar_id'], u'4bahYMkAAAAJ')
-        # Currently, fetching more than 20 coauthors works only if not using a proxy.
-        if self.connection_method=="none":
-            self.assertGreaterEqual(len(author['coauthors']), 33, "Full coauthor list not fetched")
+        # Currently, fetching more than 20 coauthors works only if a browser can be opened.
+        self.assertGreaterEqual(len(author['coauthors']), 20)
+        if len(author['coauthors'])>20:
             self.assertTrue('I23YUh8AAAAJ' in [_coauth['scholar_id'] for _coauth in author['coauthors']])
-        else:
-            self.assertEqual(len(author['coauthors']), 20)
+            self.assertGreaterEqual(len(author['coauthors']), 36, "Full coauthor list not fetched")
+
         self.assertEqual(author['homepage'], "http://steven.cholewiak.com/")
         self.assertEqual(author['organization'], 6518679690484165796)
         self.assertGreaterEqual(author['public_access']['available'], 10)


### PR DESCRIPTION
This is a continuation of the work done introducing a secondary proxy. The main feature added here is that is makes FreeProxies a lot more robust. Specifically, if a particular proxy stops working, it fetches a new one. The existing implementation used a single proxy connection for the entire execution.

@ipeirotis : I still think FreeProxies should be the default secondary proxy and here are my reasons:

- FreeProxies are more robust than they were before
- `scholarly` will fall back to the primary premium proxy (read ScraperAPI) if the secondary proxy (read FreeProxies) fail
- Fetching 20+ coauthors and funding agencies from public access mandates (coming in v1.6+) require a webdriver which cannot work with premium services like ScraperAPI (and very likely Luminati). Webdriver works with FreeProxies and fortunately both coauthor and funding agencies are `/citations?` pages that FreeProxies have no problem handling.

Note that FreeProxy becomes the default secondary proxy only if `use_proxy` method is used.

Having FreeProxies as the default secondary proxy will make it more seamless without the user having to worry about the query. And I think it is more important to support the user-facing features than to maintain the same behavior with underlying proxy methods.

If you have other reasons to keep the default behavior the same, let me know. Once we converge on this, I will write the docs appropriately in the next PR (last one from me for v1.5)

 