### PR TITLE
Maintenance v1.5.1

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,11 @@
+[flake8]
+count = True
+exclude =
+    scholarly/__init__.py
+    docs/conf.py
+ignore = E261, E265
+max-complexity = 10
+max-line-length = 127
+select = E9, F63, F7, F82, F401
+show-source = True
+statistics = True

--- a/.flake8
+++ b/.flake8
@@ -6,6 +6,6 @@ exclude =
 ignore = E261, E265
 max-complexity = 10
 max-line-length = 127
-select = E9, F63, F7, F82, F401
+select = E9, E111, F63, F7, F82, F401
 show-source = True
 statistics = True

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+---
+permalink: /contributing.html
+---
+
 # Developers' Notes
 
 We welcome contributions from you!

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -29,8 +29,8 @@ jobs:
         run: |
           sudo apt-get install -y tor
           python3 -m pip install --upgrade pip
-          pip3 install flake8 coverage
           if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
+          if [ -f requirements-dev.txt ]; then pip3 install -r requirements-dev.txt; fi
       - name: Lint with flake8
         run: |
           # Stop the build if there are Python syntax errors, undefined names or unused imports etc.

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -33,10 +33,11 @@ jobs:
           if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
       - name: Lint with flake8
         run: |
-          # stop the build if there are Python syntax errors or undefined names
-          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+          # Stop the build if there are Python syntax errors, undefined names or unused imports etc.
+          flake8
+          # Do not stop the build, but indicate room for improvement.
+          # exit-zero treats all errors as warnings.
+          flake8 . --exit-zero --ignore= --select=
       #- name: Typilus, Suggest Python Type Annotations
       #  uses: typilus/typilus-action@v0.9
       - name: Setup Tor to allow for password-based refresh of ID

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -25,19 +25,19 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          sudo apt-get install -y tor
-          python3 -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
-          if [ -f requirements-dev.txt ]; then pip3 install -r requirements-dev.txt; fi
       - name: Lint with flake8
         run: |
+          if [ -f requirements-dev.txt ]; then pip3 install -r requirements-dev.txt; fi
           # Stop the build if there are Python syntax errors, undefined names or unused imports etc.
           flake8
           # Do not stop the build, but indicate room for improvement.
           # exit-zero treats all errors as warnings.
           flake8 . --exit-zero --ignore= --select=
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y tor
+          python3 -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
       #- name: Typilus, Suggest Python Type Annotations
       #  uses: typilus/typilus-action@v0.9
       - name: Setup Tor to allow for password-based refresh of ID

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ vic.py
 .env
 .vscode/settings.json
 test.py
+*.swp

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,6 @@
+---
+permalink: /coc.html
+---
 # Code of Conduct
 
 ## Our Pledge

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ If you have used this codebase in a scientific publication, please cite this sof
   author  = {Cholewiak, Steven A. and Ipeirotis, Panos and Silva, Victor and Kannawadi, Arun},
   title   = {{SCHOLARLY: Simple access to Google Scholar authors and citation using Python}},
   year    = {2021},
-  doi     = {10.5821/zenodo.5764802},
+  doi     = {10.5281/zenodo.5764801},
   license = {Unlicense},
   url = {https://github.com/scholarly-python-package/scholarly},
   version = {1.5.0}

--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ or `pip` to install from github:
 pip3 install -U git+https://github.com/scholarly-python-package/scholarly.git
 ```
 
+We are constantly developing new features.
+Please update your local package regularly.
 `scholarly` follows [Semantic Versioning](https://semver.org/).
+This means your code that uses an earlier version of `scholarly` is guaranteed to work with newer versions.
 
 ### Optional dependencies
 
@@ -115,7 +118,13 @@ It is therefore recommended to always set up a proxy in the beginning of your ap
 The developers use `ScraperAPI` to run the tests in Github Actions.
 The developers of `scholarly` are not affiliated with any of the proxy services and do not profit from them. If your favorite service is not supported, please submit an issue or even better, follow it up with a pull request.
 
-## Citing
+## Contributing
+
+We welcome contributions from you.
+Please create an issue, fork this repository and submit a pull request.
+Read the [contributing document](.github/CONTRIBUTING.md) for more information.
+
+## Acknowledging `scholarly`
 
 If you have used this codebase in a scientific publication, please cite this software as following:
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ If you have used this codebase in a scientific publication, please cite this sof
   doi     = {10.5281/zenodo.5764801},
   license = {Unlicense},
   url = {https://github.com/scholarly-python-package/scholarly},
-  version = {1.5.0}
+  version = {1.5.1}
 }
 ```
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,8 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'scholarlyORG'
-copyright = '2020, Steven A. Cholewiak, Panos Ipeirotis, Victor Silva'
-author = 'Steven A. Cholewiak, Panos Ipeirotis, Victor Silva'
+copyright = '2021, Steven A. Cholewiak, Panos Ipeirotis, Victor Silva, Arun Kannawadi'
+author = 'Steven A. Cholewiak, Panos Ipeirotis, Victor Silva, Arun Kannawadi'
 
 # The full version, including alpha/beta/rc tags
 release = '1.0b1'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+coverage
+flake8
+sphinx_rtd_theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ fake_useragent
 selenium
 python-dotenv
 free-proxy
-sphinx_rtd_theme

--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -4,25 +4,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from ._proxy_generator import ProxyGenerator, MaxTriesExceededException, DOSException
 
-from typing import Callable
 from bs4 import BeautifulSoup
 
 import codecs
-import hashlib
 import logging
 import random
 import time
-import requests
-import tempfile
 from requests.exceptions import Timeout
-from selenium import webdriver
-from selenium.webdriver.support.wait import WebDriverWait, TimeoutException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions
-from selenium.common.exceptions import WebDriverException, UnexpectedAlertPresentException
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
-from urllib.parse import urlparse
-from fake_useragent import UserAgent
 from .publication_parser import _SearchScholarIterator
 from .author_parser import AuthorParser
 from .publication_parser import PublicationParser

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -7,13 +7,10 @@ import requests
 import tempfile
 import urllib3
 
-from requests.exceptions import Timeout
 from selenium import webdriver
 from selenium.webdriver.support.wait import WebDriverWait, TimeoutException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions
 from selenium.common.exceptions import WebDriverException, UnexpectedAlertPresentException
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from urllib.parse import urlparse
 from fake_useragent import UserAgent
 from contextlib import contextmanager
@@ -34,16 +31,6 @@ class DOSException(Exception):
 
 class MaxTriesExceededException(Exception):
     """Maximum number of tries by scholarly reached"""
-
-
-class Singleton(type):
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args,
-                                                                 **kwargs)
-        return cls._instances[cls]
 
 
 class ProxyGenerator(object):

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -373,10 +373,10 @@ class ProxyGenerator(object):
                 self.logger.info(f"Unexpected alert while waiting for captcha completion: {e.args}")
                 time.sleep(15)
             except DOSException as e:
-                self.logger.info(f"Google thinks we are DOSing the captcha.")
+                self.logger.info("Google thinks we are DOSing the captcha.")
                 raise e
             except (WebDriverException) as e:
-                self.logger.info(f"Browser seems to be disfunctional - closed by user?")
+                self.logger.info("Browser seems to be disfunctional - closed by user?")
                 raise e
             except Exception as e:
                 # TODO: This exception handler should eventually be removed when

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -26,6 +26,7 @@ class _Scholarly:
         load_dotenv(find_dotenv())
         self.env = os.environ.copy()
         self.__nav = Navigator()
+        self.logger = self.__nav.logger
 
     def set_retries(self, num_retries: int)->None:
         """Sets the number of retries in case of errors
@@ -235,7 +236,7 @@ class _Scholarly:
             publication_parser = PublicationParser(self.__nav)
             return publication_parser.bibtex(object)
         else:
-            print("Object not supported for bibtex exportation")
+            self.logger.warning("Object not supported for bibtex exportation")
             return
 
     def citedby(self, object: Publication)->_SearchScholarIterator:
@@ -249,9 +250,8 @@ class _Scholarly:
             publication_parser = PublicationParser(self.__nav)
             return publication_parser.citedby(object)
         else:
-            print("Object not supported for bibtex exportation")
+            self.logger.warning("Object not supported for bibtex exportation")
             return
-
 
     def search_author_id(self, id: str, filled: bool = False, sortby: str = "citedby", publication_limit: int = 0)->Author:
         """Search by author id and return a single Author object
@@ -352,8 +352,6 @@ class _Scholarly:
         url = _KEYWORDSEARCHBASE.format(formated_keywords)
         return self.__nav.search_authors(url)
 
-
-
     def search_pubs_custom_url(self, url: str)->_SearchScholarIterator:
         """Search by custom URL and return a generator of Publication objects
         URL should be of the form '/scholar?q=...'
@@ -380,7 +378,7 @@ class _Scholarly:
         :type object: Publication
         """
         if object['container_type'] != 'Publication':
-            print("Not a publication object")
+            self.logger.warning("Not a publication object")
             return
 
         if object['source'] == PublicationSource.AUTHOR_PUBLICATION_ENTRY:
@@ -397,7 +395,7 @@ class _Scholarly:
         :type object: Author or Publication
         """
         if 'container_type' not in object:
-            print("Not a scholarly container object")
+            self.logger.warning("Not a scholarly container object")
             return
 
         to_print = copy.deepcopy(object)

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -356,6 +356,10 @@ class _Scholarly:
         """Search by custom URL and return a generator of Publication objects
         URL should be of the form '/scholar?q=...'
 
+        A typical use case is to generate the URL by first typing in search
+        parameters in the Advanced Search dialog box and then use the URL here
+        to programmatically fetch the results.
+
         :param url: custom url to seach for the publication
         :type url: string
         """

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -232,8 +232,8 @@ class _Scholarly:
         :type object: Publication
         """
         if object['container_type'] == "Publication":
-           publication_parser = PublicationParser(self.__nav)
-           return publication_parser.bibtex(object)
+            publication_parser = PublicationParser(self.__nav)
+            return publication_parser.bibtex(object)
         else:
             print("Object not supported for bibtex exportation")
             return
@@ -246,8 +246,8 @@ class _Scholarly:
         :type object: Publication
         """
         if object['container_type'] == "Publication":
-           publication_parser = PublicationParser(self.__nav)
-           return publication_parser.citedby(object)
+            publication_parser = PublicationParser(self.__nav)
+            return publication_parser.citedby(object)
         else:
             print("Object not supported for bibtex exportation")
             return

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -1,10 +1,9 @@
 """scholarly.py"""
 import requests
-import random
 import os
 import copy
 import pprint
-from typing import Callable, List
+from typing import List
 from ._navigator import Navigator
 from ._proxy_generator import ProxyGenerator
 from dotenv import find_dotenv, load_dotenv
@@ -36,7 +35,6 @@ class _Scholarly:
         """
 
         return self.__nav._set_retries(num_retries)
-
 
     def use_proxy(self, proxy_generator: ProxyGenerator,
                   secondary_proxy_generator: ProxyGenerator = None) -> None:
@@ -75,7 +73,6 @@ class _Scholarly:
     def set_timeout(self, timeout: int):
         """Set timeout period in seconds for scholarly"""
         self.__nav.set_timeout(timeout)
-
 
     def search_pubs(self,
                     query: str, patents: bool = True,

--- a/scholarly/author_parser.py
+++ b/scholarly/author_parser.py
@@ -1,7 +1,6 @@
 from .publication_parser import PublicationParser
 import re
 from .data_types import Author, AuthorSource, PublicationSource, PublicAccess
-from selenium.common.exceptions import WebDriverException
 import codecs
 
 _CITATIONAUTHRE = r'user=([\w-]*)'

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -1,7 +1,6 @@
 import re
 import bibtexparser
 import arrow
-import pprint
 from bibtexparser.bibdatabase import BibDatabase
 from .data_types import BibEntry, Publication, PublicationSource
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='scholarly',
-    version='1.5.0',
+    version='1.5.1',
     author='Steven A. Cholewiak, Panos Ipeirotis, Victor Silva, Arun Kannawadi',
     author_email='steven@cholewiak.com, panos@stern.nyu.edu, vsilva@ualberta.ca, arunkannawadi@astro.princeton.edu',
     description='Simple access to Google Scholar authors and citations',

--- a/test_module.py
+++ b/test_module.py
@@ -5,6 +5,7 @@ from scholarly import scholarly, ProxyGenerator
 from scholarly.publication_parser import PublicationParser
 import random
 import json
+from contextlib import contextmanager
 
 
 class TestLuminati(unittest.TestCase):
@@ -76,6 +77,9 @@ class TestScholarly(unittest.TestCase):
         """
         Setup the proxy methods for unit tests
         """
+        scholarly.set_timeout(5)
+        scholarly.set_retries(5)
+
         if "CONNECTION_METHOD" in scholarly.env:
             cls.connection_method = os.getenv("CONNECTION_METHOD")
         else:
@@ -131,6 +135,17 @@ class TestScholarly(unittest.TestCase):
             scholarly.use_proxy(None)
 
         scholarly.use_proxy(proxy_generator, secondary_proxy_generator)
+
+    @staticmethod
+    @contextmanager
+    def suppress_stdout():
+        with open(os.devnull, "w") as devnull:
+            old_stdout = sys.stdout
+            sys.stdout = devnull
+            try:
+                yield
+            finally:
+                sys.stdout = old_stdout
 
     def test_search_author_empty_author(self):
         """
@@ -212,8 +227,8 @@ class TestScholarly(unittest.TestCase):
 
         """
         )
-        query = scholarly.search_pubs("A density-based algorithm for discovering clusters in large spatial databases with noise")
-        pub = next(query)
+        pub = scholarly.search_single_pub("A density-based algorithm for discovering clusters in large "
+                                          "spatial databases with noise", filled=True)
         result = scholarly.bibtex(pub)
         self.assertEqual(result, expected_result.replace("\n        ", "\n"))
 
@@ -253,6 +268,13 @@ class TestScholarly(unittest.TestCase):
         self.assertGreaterEqual(author["citedby"], expected_author["citedby"])
         self.assertEqual(set(author["interests"]), set(expected_author["interests"]))
 
+    def test_search_keywords(self):
+        query = scholarly.search_keywords(['crowdsourcing', 'privacy'])
+        author = next(query)
+        self.assertEqual(author['scholar_id'], '_cMw1IUAAAAJ')
+        self.assertEqual(author['name'], 'Arpita Ghosh')
+        self.assertEqual(author['affiliation'], 'Cornell University')
+
     def test_search_author_single_author(self):
         query = 'Steven A. Cholewiak'
         authors = [a for a in scholarly.search_author(query)]
@@ -276,6 +298,10 @@ class TestScholarly(unittest.TestCase):
         pub = author['publications'][2]
         self.assertEqual(pub['author_pub_id'], u'4bahYMkAAAAJ:LI9QrySNdTsC')
         self.assertTrue('5738786554683183717' in pub['cites_id'])
+        # Trigger the pprint method, but suppress the output
+        with self.suppress_stdout():
+            scholarly.pprint(author)
+            scholarly.pprint(pub)
 
     def test_search_author_multiple_authors(self):
         """
@@ -324,11 +350,17 @@ class TestScholarly(unittest.TestCase):
         Check that the paper "Visual perception of the physical stability of asymmetric three-dimensional objects"
         is among them
         """
-        pubs = [p['bib']['title'] for p in scholarly.search_pubs(
-            '"naive physics" stability "3d shape"')]
+        pub = scholarly.search_single_pub("naive physics stability 3d shape")
+        pubs = list(scholarly.search_pubs('"naive physics" stability "3d shape"'))
+        # Check that the first entry in pubs is the same as pub.
+        # Checking for quality holds for non-dict entries only.
+        for key in {'author_id', 'pub_url', 'num_citations'}:
+            self.assertEqual(pub[key], pubs[0][key])
+        for key in {'title', 'pub_year', 'venue'}:
+            self.assertEqual(pub['bib'][key], pubs[0]['bib'][key])
         self.assertGreaterEqual(len(pubs), 27)
-
-        self.assertIn('Visual perception of the physical stability of asymmetric three-dimensional objects', pubs)
+        titles = [p['bib']['title'] for p in pubs]
+        self.assertIn('Visual perception of the physical stability of asymmetric three-dimensional objects', titles)
 
     @unittest.skipIf(os.getenv("CONNECTION_METHOD") in {None, "none", "freeproxy"}, reason="No robust proxy setup")
     def test_search_pubs_total_results(self):
@@ -443,8 +475,14 @@ class TestScholarly(unittest.TestCase):
     def test_author_organization(self):
         """
         """
-        organization = 4836318610601440500  # Princeton University
-        search_query = scholarly.search_author_by_organization(organization)
+        organization_id = 4836318610601440500  # Princeton University
+        organizations = scholarly.search_org("Princeton University")
+        self.assertEqual(len(organizations), 1)
+        organization = organizations[0]
+        self.assertEqual(organization['Organization'], "Princeton University")
+        self.assertEqual(organization['id'], str(organization_id))
+
+        search_query = scholarly.search_author_by_organization(organization_id)
         author = next(search_query)
         self.assertEqual(author['scholar_id'], "ImhakoAAAAAJ")
         self.assertEqual(author['name'], "Daniel Kahneman")
@@ -473,6 +511,73 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(author["scholar_id"], "ImhakoAAAAAJ")
         self.assertGreaterEqual(author["public_access"]["available"], 6)
 
+    def test_related_articles_from_author(self):
+        """
+        Test that we obtain related articles to an article from an author
+        """
+        author = scholarly.search_author_id("ImhakoAAAAAJ")
+        scholarly.fill(author, sections=['basics', 'publications'])
+        pub = author['publications'][0]
+        self.assertEqual(pub['bib']['title'], 'Prospect theory: An analysis of decision under risk')
+        related_articles = scholarly.get_related_articles(pub)
+        # Typically, the same publication is returned as the most related article
+        same_article = next(related_articles)
+        for key in {'pub_url', 'num_citations'}:
+            self.assertEqual(pub[key], same_article[key])
+        for key in {'title', 'pub_year'}:
+            self.assertEqual(str(pub['bib'][key]), (same_article['bib'][key]))
+
+        # These may change with time
+        related_article = next(related_articles)
+        self.assertEqual(related_article['bib']['title'], 'Choices, values, and frames')
+        self.assertEqual(related_article['bib']['pub_year'], '2013')
+        self.assertGreaterEqual(related_article['num_citations'], 16561)
+        self.assertIn("A Tversky", related_article['bib']['author'])
+
+    @unittest.skipIf(os.getenv("CONNECTION_METHOD") in {None, "none", "freeproxy"}, reason="No robust proxy setup")
+    def test_related_articles_from_publication(self):
+        """
+        Test that we obtain related articles to an article from a search
+        """
+        pub = scholarly.search_single_pub("Planck 2018 results-VI. Cosmological parameters")
+        related_articles = scholarly.get_related_articles(pub)
+        # Typically, the same publication is returned as the most related article
+        same_article = next(related_articles)
+        for key in {'author_id', 'pub_url', 'num_citations'}:
+            self.assertEqual(pub[key], same_article[key])
+        for key in {'title', 'pub_year'}:
+            self.assertEqual(pub['bib'][key], same_article['bib'][key])
+
+        # These may change with time
+        related_article = next(related_articles)
+        self.assertEqual(related_article['bib']['title'], 'Large Magellanic Cloud Cepheid standards provide '
+                         'a 1% foundation for the determination of the Hubble constant and stronger evidence '
+                         'for physics beyond ΛCDM')
+        self.assertEqual(related_article['bib']['pub_year'], '2019')
+        self.assertGreaterEqual(related_article['num_citations'], 1388)
+        self.assertIn("AG Riess", related_article['bib']['author'])
+
+    def test_author_custom_url(self):
+        """
+        Test that we can use custom URLs for retrieving author data
+        """
+        query_url = "/citations?hl=en&view_op=search_authors&mauthors=label%3A3d_shape"
+        authors = scholarly.search_author_custom_url(query_url)
+        self.assertIn(u'Steven A. Cholewiak, PhD', [author['name'] for author in authors])
+
+    @unittest.skipIf(os.getenv("CONNECTION_METHOD") in {None, "none", "freeproxy"}, reason="No robust proxy setup")
+    def test_pubs_custom_url(self):
+        """
+        Test that we can use custom URLs for retrieving publication data
+        """
+        query_url = ('/scholar?as_q=&as_epq=&as_oq=SFDI+"modulated+imaging"&as_eq=&as_occt=any&as_sauthors=&'
+                     'as_publication=&as_ylo=2005&as_yhi=2020&hl=en&as_sdt=0%2C31')
+        pubs = scholarly.search_pubs_custom_url(query_url)
+        pub = next(pubs)
+        self.assertEqual(pub['bib']['title'], 'Quantitation and mapping of tissue optical properties using modulated imaging')
+        self.assertEqual(set(pub['author_id']), {'V-ab9U4AAAAJ', '4k-k6SEAAAAJ', 'GLm-SaQAAAAJ'})
+        self.assertEqual(pub['bib']['pub_year'], '2009')
+        self.assertGreaterEqual(pub['num_citations'], 581)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The release v1.5.0 was almost broken caused by unused imports of `stem` package which became an optional dependency. This PR introduces slightly stricter flake8 rules, with the hope of gradually imposing stricter rules with subsequent versions. Also, the test coverage is significantly increased by testing all public scholarly APIs.
