### PR TITLE
Define webdriver when instantiating ProxyGenerator

### DIFF
--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -48,6 +48,7 @@ class ProxyGenerator(object):
         self._can_refresh_tor = False
         self._tor_control_port = None
         self._tor_password = None
+        self._webdriver = None
         self._session = None
         self._TIMEOUT = 5
         self._new_session()


### PR DESCRIPTION
Fixes #403

I still don't see how issue #403 could arise, but defined _webdriver in __init__ of ProxyGenerator as a fail safe.