### PR TITLE
Test different os

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,13 +35,10 @@ jobs:
           flake8 . --exit-zero --ignore= --select=
       - name: Install dependencies
         run: |
-          sudo apt-get install -y tor
           python3 -m pip install --upgrade pip
           if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
       #- name: Typilus, Suggest Python Type Annotations
       #  uses: typilus/typilus-action@v0.9
-      - name: Setup Tor to allow for password-based refresh of ID
-        run: ./scripts/setup_tor.sh
       - name: Install Chrome
         uses: browser-actions/setup-chrome@latest
       - name: Test with unittest

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,11 +13,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 180
     strategy:
+      fail-fast: false
       matrix:
         python-version: [3.8]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v2
@@ -49,10 +51,16 @@ jobs:
           USERNAME: ${{ secrets.USERNAME }}
           SCRAPER_API_KEY: ${{ secrets.SCRAPER_API_KEY }}
         run: |
-          curl --data-binary @.github/.codecov.yml https://codecov.io/validate | head -n 1
           coverage run -m unittest -v test_module.TestScholarly
           coverage xml
+      - name: Validate the repository yaml for codecov
+        if:
+          "matrix.os == 'ubuntu-latest'"
+        run:
+          curl --data-binary @.github/.codecov.yml https://codecov.io/validate | head -n 1
       - name: Upload code coverage
+        if:
+          "matrix.os != 'windows-latest'"
         uses: codecov/codecov-action@v2
         with:
           directory: ./

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -27,7 +27,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Lint with flake8
         run: |
-          if [ -f requirements-dev.txt ]; then pip3 install -r requirements-dev.txt; fi
+          pip3 install -r requirements-dev.txt
           # Stop the build if there are Python syntax errors, undefined names or unused imports etc.
           flake8
           # Do not stop the build, but indicate room for improvement.
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip3 install -r requirements.txt; fi
+          pip3 install -r requirements.txt
       #- name: Typilus, Suggest Python Type Annotations
       #  uses: typilus/typilus-action@v0.9
       - name: Install Chrome

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 180
     strategy:
       matrix:
         python-version: [3.8]


### PR DESCRIPTION
PR to test `scholarly` on ubuntu, macOS and windows in Github Actions.

This was desired in #89 but my primary reasons to do this now:

1. A number of issues opened recently seemed to report trouble running `scholarly` on Windows.
2. Some of the new features that consistently passed successfully on my system (macOS) consistently failed in Github Actions, which ran on ubuntu.

Note: There is no necessity to release a tagged version, since the changes have to do with the repo maintenance than the package itself.
