### PR TITLE
Simplified URL for fetching coauthors

### DIFF
--- a/scholarly/author_parser.py
+++ b/scholarly/author_parser.py
@@ -9,9 +9,7 @@ _HOST = 'https://scholar.google.com{0}'
 _PAGESIZE = 100
 _EMAILAUTHORRE = r'Verified email at '
 _CITATIONAUTH = '/citations?hl=en&user={0}'
-_COAUTH = ('https://scholar.google.com/citations?user={0}&hl=en'
-           '#d=gsc_md_cod&u=%2Fcitations%3Fview_op%3Dlist_colleagues'
-           '%26hl%3Den%26json%3D%26user%3D{0}%23t%3Dgsc_cod_lc')
+_COAUTH = 'https://scholar.google.com/citations?view_op=list_colleagues&hl=en&user={0}'
 _MANDATES = "/citations?hl=en&tzom=300&user={0}&view_op=list_mandates&pagesize={1}"
 
 


### PR DESCRIPTION
Fixes #Enter the associated issue number.

### Description

I am very uncertain about it, but it seems that we can now fetch the full list of co-authors without having to use selenium with geckodriver. The simplified URL seems to include directly the full list of co-authors. I did not attempt to change fully the logic.

## Checklist

- [X] Check that the base branch is set to `develop` and **not** `main`.
- [X] Ensure that the documentation will be consistent with the code upon merging.
- [X] Add a line or a few lines that check the new features added.
- [X] Ensure that unit tests pass.
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
