### PR TITLE
Added ability to insert delay between page requests and corrected pub_year to year

### DIFF
--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -272,7 +272,10 @@ class Navigator(object, metaclass=Singleton):
             pub = publication_parser.fill(pub)
         return pub
 
-    def search_publications(self, url: str) -> _SearchScholarIterator:
+    def search_publications(self, url: str,
+                            delay_in_seconds: float = None,
+                            delay_from_function: any = None
+                            ) -> _SearchScholarIterator:
         """Returns a Publication Generator given a url
 
         :param url: the url where publications can be found.
@@ -280,7 +283,9 @@ class Navigator(object, metaclass=Singleton):
         :returns: An iterator of Publications
         :rtype: {_SearchScholarIterator}
         """
-        return _SearchScholarIterator(self, url)
+        return _SearchScholarIterator(self, url,
+                                      delay_in_seconds,
+                                      delay_from_function)
 
     def search_author_id(self, id: str, filled: bool = False, sortby: str = "citedby", publication_limit: int = 0) -> Author:
         """Search by author ID and return a Author object

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -89,6 +89,8 @@ class _Scholarly:
                     citations: bool = True, year_low: int = None,
                     year_high: int = None, sort_by: str = "relevance",
                     include_last_year: str = "abstracts",
+                    delay_in_seconds: float = None,
+                    delay_from_function: any = None,
                     start_index: int = 0)->_SearchScholarIterator:
         """Searches by query and returns a generator of Publication objects
 
@@ -153,7 +155,9 @@ class _Scholarly:
         url = self._construct_url(_PUBSEARCH.format(requests.utils.quote(query)), patents=patents,
                                   citations=citations, year_low=year_low, year_high=year_high,
                                   sort_by=sort_by, include_last_year=include_last_year, start_index=start_index)
-        return self.__nav.search_publications(url)
+        return self.__nav.search_publications(url,
+                                              delay_in_seconds,
+                                              delay_from_function)
 
     def search_citedby(self, publication_id: int, **kwargs):
         """Searches by Google Scholar publication id and returns a generator of Publication objects.

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -112,7 +112,7 @@ class BibEntry(TypedDict, total=False):
     :param abstract: description of the publication
     :param title: title of the publication
     :param author: list of author the author names that contributed to this publication
-    :param year: the year the publication was first published
+    :param pub_year: the year the publication was first published
     :param venue: the venue of the publication (source: PUBLICATION_SEARCH_SNIPPET)
     :param journal: Journal Name
     :param volume: number of years a publication has been circulated
@@ -127,7 +127,7 @@ class BibEntry(TypedDict, total=False):
     abstract: str
     title: str
     author: str
-    year: str
+    pub_year: str
     venue: str
     journal: str
     volume: str

--- a/scholarly/data_types.py
+++ b/scholarly/data_types.py
@@ -112,7 +112,7 @@ class BibEntry(TypedDict, total=False):
     :param abstract: description of the publication
     :param title: title of the publication
     :param author: list of author the author names that contributed to this publication
-    :param pub_year: the year the publication was first published
+    :param year: the year the publication was first published
     :param venue: the venue of the publication (source: PUBLICATION_SEARCH_SNIPPET)
     :param journal: Journal Name
     :param volume: number of years a publication has been circulated
@@ -127,7 +127,7 @@ class BibEntry(TypedDict, total=False):
     abstract: str
     title: str
     author: str
-    pub_year: str
+    year: str
     venue: str
     journal: str
     volume: str

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -99,7 +99,7 @@ class _SearchScholarIterator(object):
                 seconds = self._delay_in_seconds
                 time.sleep(seconds)
             if self._delay_from_function is not None:
-                fseconds = self._delay_from_function()
+                fseconds = self._delay_from_function
                 time.sleep(fseconds)
             self._load_url(url)
             return self.__next__()

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -18,6 +18,7 @@ _MANDATES_URL = '/citations?view_op=view_mandate&hl=en&citation_for_view={0}'
 _BIB_MAPPING = {
     'ENTRYTYPE': 'pub_type',
     'ID': 'bib_id',
+    'year': 'pub_year',
 }
 
 _BIB_DATATYPES = {
@@ -139,7 +140,7 @@ class PublicationParser(object):
         if (year and year.text
                 and not year.text.isspace()
                 and len(year.text) > 0):
-            publication['bib']['year'] = year.text.strip()
+            publication['bib']['pub_year'] = year.text.strip()
 
         author_citation = __data.find_all('div', class_='gs_gray')
         try:
@@ -236,18 +237,18 @@ class PublicationParser(object):
         venueyear = authorinfo.split(' - ')
         # If there is no middle part (A) then venue and year are unknown.
         if len(venueyear) <= 2:
-            publication['bib']['venue'], publication['bib']['year'] = 'NA', 'NA'
+            publication['bib']['venue'], publication['bib']['pub_year'] = 'NA', 'NA'
         else:
             venueyear = venueyear[1].split(',')
             venue = 'NA'
             year = venueyear[-1].strip()
             if year.isnumeric() and len(year) == 4:
-                publication['bib']['year'] = year
+                publication['bib']['pub_year'] = year
                 if len(venueyear) >= 2:
                     venue = ','.join(venueyear[0:-1]) # everything but last
             else:
                 venue = ','.join(venueyear) # everything
-                publication['bib']['year'] = 'NA'
+                publication['bib']['pub_year'] = 'NA'
             publication['bib']['venue'] = venue
 
         if databox.find('div', class_='gs_rs'):
@@ -326,7 +327,7 @@ class PublicationParser(object):
                                 'YYYY/M/DD',
                                 'YYYY/M/D',
                                 'YYYY/MM/D']
-                    publication['bib']['year'] = arrow.get(val.text, patterns).year
+                    publication['bib']['pub_year'] = arrow.get(val.text, patterns).year
                 elif key == 'description':
                     # try to find all the gsh_csp if they exist
                     abstract = val.find_all(class_='gsh_csp')

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -1,6 +1,7 @@
 import re
 import bibtexparser
 import arrow
+import time
 from bibtexparser.bibdatabase import BibDatabase
 from .data_types import BibEntry, Mandate, Publication, PublicationSource
 

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -46,13 +46,17 @@ class _SearchScholarIterator(object):
     I have removed all logging from here for simplicity. -V
     """
 
-    def __init__(self, nav, url: str):
+    def __init__(self, nav, url: str,
+                 delay_in_seconds: float = None,
+                 delay_from_function: any = None):
         self._url = url
         self._pubtype = PublicationSource.PUBLICATION_SEARCH_SNIPPET if "/scholar?" in url else PublicationSource.JOURNAL_CITATION_LIST
         self._nav = nav
         self._load_url(url)
         self.total_results = self._get_total_results()
         self.pub_parser = PublicationParser(self._nav)
+        self._delay_in_seconds = delay_in_seconds
+        self._delay_from_function = delay_from_function
 
     def _load_url(self, url: str):
         # this is temporary until setup json file
@@ -87,6 +91,16 @@ class _SearchScholarIterator(object):
             url = self._soup.find(
                 class_='gs_ico gs_ico_nav_next').parent['href']
             self._url = url
+            # Optional creation of time delays between page requests;
+            # a user could use both at once if desired.
+            seconds = 0
+            fseconds = 0               
+            if self._delay_in_seconds is not None:
+                seconds = self._delay_in_seconds
+                time.sleep(seconds)
+            if self._delay_from_function is not None:
+                fseconds = self._delay_from_function()
+                time.sleep(fseconds)
             self._load_url(url)
             return self.__next__()
         else:

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -18,7 +18,6 @@ _MANDATES_URL = '/citations?view_op=view_mandate&hl=en&citation_for_view={0}'
 _BIB_MAPPING = {
     'ENTRYTYPE': 'pub_type',
     'ID': 'bib_id',
-    'year': 'pub_year',
 }
 
 _BIB_DATATYPES = {
@@ -140,7 +139,7 @@ class PublicationParser(object):
         if (year and year.text
                 and not year.text.isspace()
                 and len(year.text) > 0):
-            publication['bib']['pub_year'] = year.text.strip()
+            publication['bib']['year'] = year.text.strip()
 
         author_citation = __data.find_all('div', class_='gs_gray')
         try:
@@ -237,18 +236,18 @@ class PublicationParser(object):
         venueyear = authorinfo.split(' - ')
         # If there is no middle part (A) then venue and year are unknown.
         if len(venueyear) <= 2:
-            publication['bib']['venue'], publication['bib']['pub_year'] = 'NA', 'NA'
+            publication['bib']['venue'], publication['bib']['year'] = 'NA', 'NA'
         else:
             venueyear = venueyear[1].split(',')
             venue = 'NA'
             year = venueyear[-1].strip()
             if year.isnumeric() and len(year) == 4:
-                publication['bib']['pub_year'] = year
+                publication['bib']['year'] = year
                 if len(venueyear) >= 2:
                     venue = ','.join(venueyear[0:-1]) # everything but last
             else:
                 venue = ','.join(venueyear) # everything
-                publication['bib']['pub_year'] = 'NA'
+                publication['bib']['year'] = 'NA'
             publication['bib']['venue'] = venue
 
         if databox.find('div', class_='gs_rs'):
@@ -327,7 +326,7 @@ class PublicationParser(object):
                                 'YYYY/M/DD',
                                 'YYYY/M/D',
                                 'YYYY/MM/D']
-                    publication['bib']['pub_year'] = arrow.get(val.text, patterns).year
+                    publication['bib']['year'] = arrow.get(val.text, patterns).year
                 elif key == 'description':
                     # try to find all the gsh_csp if they exist
                     abstract = val.find_all(class_='gsh_csp')

--- a/test_module.py
+++ b/test_module.py
@@ -242,7 +242,7 @@ class TestScholarly(unittest.TestCase):
          booktitle = {kdd},
          number = {34},
          pages = {226--231},
-         year = {1996},
+         pub_year = {1996},
          title = {A density-based algorithm for discovering clusters in large spatial databases with noise.},
          venue = {kdd},
          volume = {96}
@@ -385,7 +385,7 @@ class TestScholarly(unittest.TestCase):
         # Checking for quality holds for non-dict entries only.
         for key in {'author_id', 'pub_url', 'num_citations'}:
             self.assertEqual(pub[key], pubs[0][key])
-        for key in {'title', 'year', 'venue'}:
+        for key in {'title', 'pub_year', 'venue'}:
             self.assertEqual(pub['bib'][key], pubs[0]['bib'][key])
         self.assertGreaterEqual(len(pubs), 27)
         titles = [p['bib']['title'] for p in pubs]
@@ -429,7 +429,7 @@ class TestScholarly(unittest.TestCase):
         self.assertTrue(f['bib']['title'] == u'Creating correct blur and its effect on accommodation')
         self.assertTrue(f['pub_url'] == u'https://jov.arvojournals.org/article.aspx?articleid=2701817')
         self.assertTrue(f['bib']['volume'] == '18')
-        self.assertTrue(f['bib']['year'] == u'2018')
+        self.assertTrue(f['bib']['pub_year'] == u'2018')
 
     def test_extract_author_id_list(self):
         '''
@@ -612,13 +612,13 @@ class TestScholarly(unittest.TestCase):
         same_article = next(related_articles)
         for key in {'pub_url', 'num_citations'}:
             self.assertEqual(pub[key], same_article[key])
-        for key in {'title', 'year'}:
+        for key in {'title', 'pub_year'}:
             self.assertEqual(str(pub['bib'][key]), (same_article['bib'][key]))
 
         # These may change with time
         related_article = next(related_articles)
         self.assertEqual(related_article['bib']['title'], 'Choices, values, and frames')
-        self.assertEqual(related_article['bib']['year'], '2013')
+        self.assertEqual(related_article['bib']['pub_year'], '2013')
         self.assertGreaterEqual(related_article['num_citations'], 16561)
         self.assertIn("A Tversky", related_article['bib']['author'])
 
@@ -633,7 +633,7 @@ class TestScholarly(unittest.TestCase):
         same_article = next(related_articles)
         for key in {'author_id', 'pub_url', 'num_citations'}:
             self.assertEqual(pub[key], same_article[key])
-        for key in {'title', 'year'}:
+        for key in {'title', 'pub_year'}:
             self.assertEqual(pub['bib'][key], same_article['bib'][key])
 
         # These may change with time
@@ -641,7 +641,7 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(related_article['bib']['title'], 'Large Magellanic Cloud Cepheid standards provide '
                          'a 1% foundation for the determination of the Hubble constant and stronger evidence '
                          'for physics beyond ΛCDM')
-        self.assertEqual(related_article['bib']['year'], '2019')
+        self.assertEqual(related_article['bib']['pub_year'], '2019')
         self.assertGreaterEqual(related_article['num_citations'], 1388)
         self.assertIn("AG Riess", related_article['bib']['author'])
 
@@ -664,7 +664,7 @@ class TestScholarly(unittest.TestCase):
         pub = next(pubs)
         self.assertEqual(pub['bib']['title'], 'Quantitation and mapping of tissue optical properties using modulated imaging')
         self.assertEqual(set(pub['author_id']), {'V-ab9U4AAAAJ', '4k-k6SEAAAAJ', 'GLm-SaQAAAAJ'})
-        self.assertEqual(pub['bib']['year'], '2009')
+        self.assertEqual(pub['bib']['pub_year'], '2009')
         self.assertGreaterEqual(pub['num_citations'], 581)
 
     @unittest.skipIf(sys.platform.startswith("win"), reason="File read is empty in Windows")

--- a/test_module.py
+++ b/test_module.py
@@ -242,7 +242,7 @@ class TestScholarly(unittest.TestCase):
          booktitle = {kdd},
          number = {34},
          pages = {226--231},
-         pub_year = {1996},
+         year = {1996},
          title = {A density-based algorithm for discovering clusters in large spatial databases with noise.},
          venue = {kdd},
          volume = {96}
@@ -385,7 +385,7 @@ class TestScholarly(unittest.TestCase):
         # Checking for quality holds for non-dict entries only.
         for key in {'author_id', 'pub_url', 'num_citations'}:
             self.assertEqual(pub[key], pubs[0][key])
-        for key in {'title', 'pub_year', 'venue'}:
+        for key in {'title', 'year', 'venue'}:
             self.assertEqual(pub['bib'][key], pubs[0]['bib'][key])
         self.assertGreaterEqual(len(pubs), 27)
         titles = [p['bib']['title'] for p in pubs]
@@ -429,7 +429,7 @@ class TestScholarly(unittest.TestCase):
         self.assertTrue(f['bib']['title'] == u'Creating correct blur and its effect on accommodation')
         self.assertTrue(f['pub_url'] == u'https://jov.arvojournals.org/article.aspx?articleid=2701817')
         self.assertTrue(f['bib']['volume'] == '18')
-        self.assertTrue(f['bib']['pub_year'] == u'2018')
+        self.assertTrue(f['bib']['year'] == u'2018')
 
     def test_extract_author_id_list(self):
         '''
@@ -612,13 +612,13 @@ class TestScholarly(unittest.TestCase):
         same_article = next(related_articles)
         for key in {'pub_url', 'num_citations'}:
             self.assertEqual(pub[key], same_article[key])
-        for key in {'title', 'pub_year'}:
+        for key in {'title', 'year'}:
             self.assertEqual(str(pub['bib'][key]), (same_article['bib'][key]))
 
         # These may change with time
         related_article = next(related_articles)
         self.assertEqual(related_article['bib']['title'], 'Choices, values, and frames')
-        self.assertEqual(related_article['bib']['pub_year'], '2013')
+        self.assertEqual(related_article['bib']['year'], '2013')
         self.assertGreaterEqual(related_article['num_citations'], 16561)
         self.assertIn("A Tversky", related_article['bib']['author'])
 
@@ -633,7 +633,7 @@ class TestScholarly(unittest.TestCase):
         same_article = next(related_articles)
         for key in {'author_id', 'pub_url', 'num_citations'}:
             self.assertEqual(pub[key], same_article[key])
-        for key in {'title', 'pub_year'}:
+        for key in {'title', 'year'}:
             self.assertEqual(pub['bib'][key], same_article['bib'][key])
 
         # These may change with time
@@ -641,7 +641,7 @@ class TestScholarly(unittest.TestCase):
         self.assertEqual(related_article['bib']['title'], 'Large Magellanic Cloud Cepheid standards provide '
                          'a 1% foundation for the determination of the Hubble constant and stronger evidence '
                          'for physics beyond ΛCDM')
-        self.assertEqual(related_article['bib']['pub_year'], '2019')
+        self.assertEqual(related_article['bib']['year'], '2019')
         self.assertGreaterEqual(related_article['num_citations'], 1388)
         self.assertIn("AG Riess", related_article['bib']['author'])
 
@@ -664,7 +664,7 @@ class TestScholarly(unittest.TestCase):
         pub = next(pubs)
         self.assertEqual(pub['bib']['title'], 'Quantitation and mapping of tissue optical properties using modulated imaging')
         self.assertEqual(set(pub['author_id']), {'V-ab9U4AAAAJ', '4k-k6SEAAAAJ', 'GLm-SaQAAAAJ'})
-        self.assertEqual(pub['bib']['pub_year'], '2009')
+        self.assertEqual(pub['bib']['year'], '2009')
         self.assertGreaterEqual(pub['num_citations'], 581)
 
     @unittest.skipIf(sys.platform.startswith("win"), reason="File read is empty in Windows")


### PR DESCRIPTION
Fixes: https://github.com/scholarly-python-package/scholarly/issues/431

### Description
Scholarly did not seem to have the ability to reduce the rate of page requests. Tools such as Publish or Perish limit this rate to prevent GS lockout, so this seemed a reasonable option to add. I added the ability to have it be a single number of seconds, or to pass a custom function that generated the number in seconds. The two could be combined, if one wanted to have a constant plus a little random padding from a function.

In addition, bibtex generation seemed to mistakenly produce a field called `pub_year` that needed to be `year` to meet proper bibtex format (.e.g., Zotero would not pick up the year with `pub_year` being the year field, but it does as `year`). There was no obvious benefit to this field being `pub_year`, and evidence a previous contributor meant for it to be `year` so I changed it to `year` in all cases. 

## Checklist

- [x] Check that the base branch is set to `develop` and **not** `main`.
- [ ] Ensure that the documentation will be consistent with the code upon merging. (Should we document the delay feature?)
- [ ] Add a line or a few lines that check the new features added. (I'm not sure how to do this.)
- [x] Ensure that unit tests pass. (`python -m unittest test_module.TestScraperAPI passes`)
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
