### PR TITLE
Release v1.7.2

### DIFF
--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -15,8 +15,8 @@ from .data_types import Author, AuthorSource, Journal, Publication, PublicationS
 _AUTHSEARCH = '/citations?hl=en&view_op=search_authors&mauthors={0}'
 _KEYWORDSEARCH = '/citations?hl=en&view_op=search_authors&mauthors=label:{0}'
 _KEYWORDSEARCHBASE = '/citations?hl=en&view_op=search_authors&mauthors={}'
-_PUBSEARCH = '/scholar?hl=en&num=20&q={0}'
-_CITEDBYSEARCH = '/scholar?hl=en&num=20&cites={0}'
+_PUBSEARCH = '/scholar?hl=en&q={0}'
+_CITEDBYSEARCH = '/scholar?hl=en&cites={0}'
 _ORGSEARCH = "/citations?view_op=view_org&hl=en&org={0}"
 _MANDATES_URL = "https://scholar.google.com/citations?view_op=mandates_leaderboard_csv&hl=en"
 

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -7,11 +7,11 @@ from .data_types import BibEntry, Mandate, Publication, PublicationSource
 
 _SCHOLARPUBRE = r'cites=([\d,]*)'
 _CITATIONPUB = '/citations?hl=en&view_op=view_citation&citation_for_view={0}'
-_SCHOLARPUB = '/scholar?hl=en&num=20&oi=bibs&cites={0}'
+_SCHOLARPUB = '/scholar?hl=en&oi=bibs&cites={0}'
 _CITATIONPUBRE = r'citation_for_view=([\w-]*:[\w-]*)'
-_BIBCITE = '/scholar?hl=en&num=20&q=info:{0}:scholar.google.com/\
+_BIBCITE = '/scholar?hl=en&q=info:{0}:scholar.google.com/\
 &output=cite&scirp={1}&hl=en'
-_CITEDBYLINK = '/scholar?hl=en&num=20&cites={0}'
+_CITEDBYLINK = '/scholar?hl=en&cites={0}'
 _MANDATES_URL = '/citations?view_op=view_mandate&hl=en&citation_for_view={0}'
 
 _BIB_MAPPING = {

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name='scholarly',
-    version='1.7.1',
+    version='1.7.2',
     author='Steven A. Cholewiak, Panos Ipeirotis, Victor Silva, Arun Kannawadi',
     author_email='steven@cholewiak.com, panos@stern.nyu.edu, vsilva@ualberta.ca, arunkannawadi@astro.princeton.edu',
     description='Simple access to Google Scholar authors and citations',


### PR DESCRIPTION
The changes made in 1.7.1 was causing a lot more failures in fetching results. This PR reverts the changes made in v1.7.1 and skips unnecessarily checking if the proxy works for ScraperAPI. Instead, account API is used to check if credits remain to check if a request will be successful.