### PR TITLE
Fetch more than 1000 citations

### DIFF
--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -6,8 +6,8 @@ import copy
 import csv
 import pprint
 import datetime
-from typing import Dict, List
 import re
+from typing import Dict, List, Union
 from ._navigator import Navigator
 from ._proxy_generator import ProxyGenerator
 from dotenv import find_dotenv, load_dotenv
@@ -159,11 +159,11 @@ class _Scholarly:
                                   sort_by=sort_by, include_last_year=include_last_year, start_index=start_index)
         return self.__nav.search_publications(url)
 
-    def search_citedby(self, publication_id: int, **kwargs):
+    def search_citedby(self, publication_id: Union[int, str], **kwargs):
         """Searches by Google Scholar publication id and returns a generator of Publication objects.
 
         :param publication_id: Google Scholar publication id
-        :type publication_id: int
+        :type publication_id: int or str
 
         For the remaining parameters, see documentation of `search_pubs`.
         """


### PR DESCRIPTION
Fixes #444.

### Description
If the highly-cited publication is fetched from an author's profile, then `scholarly` will look at the annual citation histogram and adapt the year ranges to fetch as many citations as possible without exceeding 1000. This will minimize the number of queries, especially if there are years with very few citations.

## Checklist

- [x] Check that the base branch is set to `develop` and **not** `main`.
- [x] Ensure that the documentation will be consistent with the code upon merging.
- [x] Add a line or a few lines that check the new features added.
- [x] Ensure that unit tests pass.
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
