### PR TITLE
#196 fix sameSite cookie issue

### DIFF
--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -433,6 +433,7 @@ class ProxyGenerator(object):
         for cookie in self._get_webdriver().get_cookies():
             cookie.pop("httpOnly", None)
             cookie.pop("expiry", None)
+            cookie.pop("sameSite", None)
             self._session.cookies.set(**cookie)
 
         return self._session


### PR DESCRIPTION
Fixes #196

### Description
Selenium webdriver returns a cookie that requests doesn't understand! Removing that cookie simply solves the issue!