### PR TITLE
Fixes #453 and #463.

### DIFF
--- a/scholarly/_navigator.py
+++ b/scholarly/_navigator.py
@@ -31,7 +31,7 @@ class Singleton(type):
 class Navigator(object, metaclass=Singleton):
     """A class used to navigate pages on google scholar."""
 
-    def __init__(self):
+    def __init__(self,headless=False):
         super(Navigator, self).__init__()
         self.logger = logging.getLogger('scholarly')
         self._TIMEOUT = 5
@@ -39,8 +39,8 @@ class Navigator(object, metaclass=Singleton):
         # A Navigator instance has two proxy managers, each with their session.
         # `pm1` manages the primary, premium proxy.
         # `pm2` manages the secondary, inexpensive proxy.
-        self.pm1 = ProxyGenerator()
-        self.pm2 = ProxyGenerator()
+        self.pm1 = ProxyGenerator(headless=headless)
+        self.pm2 = ProxyGenerator(headless=headless)
         self._session1 = self.pm1.get_session()
         self._session2 = self.pm2.get_session()
         self.got_403 = False

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -35,9 +35,10 @@ class MaxTriesExceededException(Exception):
 
 
 class ProxyGenerator(object):
-    def __init__(self):
+    def __init__(self,headless=False):
         # setting up logger
         self.logger = logging.getLogger('scholarly')
+        self._headless = headless
 
         self._proxy_gen = None
         # If we use a proxy or Tor, we set this to True
@@ -359,7 +360,8 @@ class ProxyGenerator(object):
             }
 
         options = webdriver.ChromeOptions()
-        options.add_argument('--headless')
+        if self._headless:
+            options.add_argument('--headless')
         self._webdriver = webdriver.Chrome('chromedriver', options=options)
         self._webdriver.get("https://scholar.google.com")  # Need to pre-load to set cookies later
 
@@ -375,7 +377,8 @@ class ProxyGenerator(object):
             }
 
         options = FirefoxOptions()
-        options.add_argument('--headless')
+        if self._headless:
+            options.add_argument('--headless')
         self._webdriver = webdriver.Firefox(options=options)
         self._webdriver.get("https://scholar.google.com")  # Need to pre-load to set cookies later
 

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -28,10 +28,10 @@ _MANDATES_URL = "https://scholar.google.com/citations?view_op=mandates_leaderboa
 class _Scholarly:
     """Class that manages the API for scholarly"""
 
-    def __init__(self):
+    def __init__(self,headless=False):
         load_dotenv(find_dotenv())
         self.env = os.environ.copy()
-        self.__nav = Navigator()
+        self.__nav = Navigator(headless=headless)
         self.logger = self.__nav.logger
         self._journal_categories = None
 

--- a/scholarly/_scholarly.py
+++ b/scholarly/_scholarly.py
@@ -305,6 +305,9 @@ class _Scholarly:
             # Go one year at a time in decreasing order
             years = zip(range(year_end, year_low-1, -1), range(year_end, year_low-1, -1))
 
+        return self._citedby_long(object,years)
+
+    def _citedby_long(self, object: Publication, years):
         # Extract cites_id. Note: There could be multiple ones, separated by commas.
         m = re.search("cites=[\d+,]*", object["citedby_url"])
         pub_id = m.group()[6:]


### PR DESCRIPTION
### Description

For #453, this is just a programming error. You should not mix `return` and `yield` in a single function.

For #463, this is generally the problem of captcha.
I enabled the GUI (which can be turned back off, as it used to be), and allowed the user to click on the browser to answer captcha.
This largely avoids the need for proxy --- indeed, why trying to circumvent captcha in a sneaky way (like proxies) when  asking captcha is possible?

## Checklist

- [X] Check that the base branch is set to `develop` and **not** `main`.
- [ ] Ensure that the documentation will be consistent with the code upon merging.
- [ ] Add a line or a few lines that check the new features added.
- [ ] Ensure that unit tests pass.
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
