### PR TITLE
fix: scholarly fails with outdated fake-useragent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ arrow
 beautifulsoup4
 bibtexparser
 deprecated
-fake_useragent
+fake_useragent>=1.0
 free-proxy
 httpx
 python-dotenv


### PR DESCRIPTION
Getting `fake_useragent.errors.FakeUserAgentError: Maximum amount of retries reached` already on `import scholarly` with fake-useragent v0.1.11 Fixed by upgrading fake-useragent to 1.0

Fixes #Enter the associated issue number.

### Description
Describe your addition briefly to help the reviewers understand your contribution.

## Checklist

- [x] Check that the base branch is set to `develop` and **not** `main`.
- [x] Ensure that the documentation will be consistent with the code upon merging.
- [ ] Add a line or a few lines that check the new features added.
- [ ] Ensure that unit tests pass.
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
