### PR TITLE
fix: set minimum free-proxy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ beautifulsoup4
 bibtexparser
 deprecated
 fake_useragent
-free-proxy
+free-proxy>=1.1.0
 httpx
 python-dotenv
 requests[socks]


### PR DESCRIPTION
scholarly requires free-proxy >= 1.1.0, see
```
  File "/.../scholarly/_proxy_generator.py", line 509, in _fp_coroutine
    all_proxies = freeproxy.get_proxy_list(repeat=False)  # free-proxy >= 1.1.0
TypeError: get_proxy_list() got an unexpected keyword argument 'repeat'
```

Fixes #Enter the associated issue number.

### Description
Describe your addition briefly to help the reviewers understand your contribution.

## Checklist

- [x] Check that the base branch is set to `develop` and **not** `main`.
- [x] Ensure that the documentation will be consistent with the code upon merging.
- [ ] Add a line or a few lines that check the new features added.
- [ ] Ensure that unit tests pass.
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
