### PR TITLE
resolve conflict between proxy format: HTTPX and Requests

### DIFF
--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -523,7 +523,6 @@ class ProxyGenerator(object):
             proxies = {'http://': proxy, 'https://': proxy}
             proxy_works = self._check_proxy(proxies)
             if proxy_works:
-                print(proxies)
                 dirty_proxy = (yield proxy)
                 t1 = time.time()
             else:

--- a/scholarly/_proxy_generator.py
+++ b/scholarly/_proxy_generator.py
@@ -136,7 +136,8 @@ class ProxyGenerator(object):
         :rtype: {bool}
         """
         with requests.Session() as session:
-            session.proxies = proxies
+            # Reformat proxy for requests. Requests and HTTPX use different proxy format.
+            session.proxies = {'http':proxies['http://'], 'https':proxies['https://']}
             try:
                 resp = session.get("http://httpbin.org/ip", timeout=self._TIMEOUT)
                 if resp.status_code == 200:
@@ -189,6 +190,7 @@ class ProxyGenerator(object):
         :returns: whether or not the proxy was set up successfully
         :rtype: {bool}
         """
+        # Reformat proxy for HTTPX
         if http[:4] not in ("http", "sock"):
             http = "http://" + http
         if https is None:
@@ -521,6 +523,7 @@ class ProxyGenerator(object):
             proxies = {'http://': proxy, 'https://': proxy}
             proxy_works = self._check_proxy(proxies)
             if proxy_works:
+                print(proxies)
                 dirty_proxy = (yield proxy)
                 t1 = time.time()
             else:


### PR DESCRIPTION
Fixes #498 and #475, possibly #493 as well.

### Description
resolve conflict between proxy format: HTTPX and Requests

The `check_proxy` use `requests`, but the proxy is in `HTTPX` format.

## Checklist

- [x] Check that the base branch is set to `develop` and **not** `main`.
- [x] Ensure that the documentation will be consistent with the code upon merging.
- [x] Add a line or a few lines that check the new features added.
- [x] Ensure that unit tests pass.
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
