### PR TITLE
Add in PDF link in publication fill

### DIFF
--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -286,6 +286,10 @@ class PublicationParser(object):
             if soup.find('a', class_='gsc_oci_title_link'):
                 publication['pub_url'] = soup.find(
                     'a', class_='gsc_oci_title_link')['href']
+            if soup.find('div', class_='gsc_oci_title_ggi'):
+                link = soup.find('a', attrs={'data-clk': True})
+                if link:
+                    publication['pdf_url'] = link['href']
             for item in soup.find_all('div', class_='gs_scl'):
                 key = item.find(class_='gsc_oci_field').text.strip().lower()
                 val = item.find(class_='gsc_oci_value')

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -202,6 +202,10 @@ class PublicationParser(object):
         if title.find('a'):
             publication['pub_url'] = title.find('a')['href']
 
+        pdf_div = __data.find('div', class_='gs_ggs gs_fl')
+        if pdf_div and pdf_div.find('a', href=True):
+            publication['pdf_url'] = pdf_div.find('a')['href']
+
         author_div_element = databox.find('div', class_='gs_a')
         authorinfo = author_div_element.text
         authorinfo = authorinfo.replace(u'\xa0', u' ')       # NBSP

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -204,7 +204,7 @@ class PublicationParser(object):
 
         pdf_div = __data.find('div', class_='gs_ggs gs_fl')
         if pdf_div and pdf_div.find('a', href=True):
-            publication['pdf_url'] = pdf_div.find('a')['href']
+            publication['eprint_url'] = pdf_div.find('a')['href']
 
         author_div_element = databox.find('div', class_='gs_a')
         authorinfo = author_div_element.text
@@ -293,7 +293,7 @@ class PublicationParser(object):
             if soup.find('div', class_='gsc_oci_title_ggi'):
                 link = soup.find('a', attrs={'data-clk': True})
                 if link:
-                    publication['pdf_url'] = link['href']
+                    publication['eprint_url'] = link['href']
             for item in soup.find_all('div', class_='gs_scl'):
                 key = item.find(class_='gsc_oci_field').text.strip().lower()
                 val = item.find(class_='gsc_oci_value')

--- a/test_module.py
+++ b/test_module.py
@@ -724,7 +724,7 @@ class TestScholarlyWithProxy(unittest.TestCase):
         pubs = list(scholarly.search_pubs('"naive physics" stability "3d shape"'))
         # Check that the first entry in pubs is the same as pub.
         # Checking for quality holds for non-dict entries only.
-        for key in {'author_id', 'pub_url', 'num_citations'}:
+        for key in {'author_id', 'pub_url', 'pdf_url', 'num_citations'}:
             self.assertEqual(pub[key], pubs[0][key])
         for key in {'title', 'pub_year', 'venue'}:
             self.assertEqual(pub['bib'][key], pubs[0]['bib'][key])
@@ -784,6 +784,7 @@ class TestScholarlyWithProxy(unittest.TestCase):
         self.assertTrue(f['bib']['publisher'] == u'The Association for Research in Vision and Ophthalmology')
         self.assertTrue(f['bib']['title'] == u'Creating correct blur and its effect on accommodation')
         self.assertTrue(f['pub_url'] == u'https://jov.arvojournals.org/article.aspx?articleid=2701817')
+        self.assertTrue(f['pdf_url'] == u'https://jov.arvojournals.org/arvo/content_public/journal/jov/937491/i1534-7362-18-9-1.pdf')
         self.assertTrue(f['bib']['volume'] == '18')
         self.assertTrue(f['bib']['pub_year'] == u'2018')
 
@@ -800,6 +801,7 @@ class TestScholarlyWithProxy(unittest.TestCase):
         # Typically, the same publication is returned as the most related article
         same_article = next(related_articles)
         self.assertEqual(pub["pub_url"], same_article["pub_url"])
+        self.assertEqual(pub["pdf_url"], same_article["pdf_url"])
         for key in {'title', 'pub_year'}:
             self.assertEqual(str(pub['bib'][key]), (same_article['bib'][key]))
 
@@ -818,7 +820,7 @@ class TestScholarlyWithProxy(unittest.TestCase):
         related_articles = scholarly.get_related_articles(pub)
         # Typically, the same publication is returned as the most related article
         same_article = next(related_articles)
-        for key in {'author_id', 'pub_url', 'num_citations'}:
+        for key in {'author_id', 'pub_url', 'pdf_url', 'num_citations'}:
             self.assertEqual(pub[key], same_article[key])
         for key in {'title', 'pub_year'}:
             self.assertEqual(pub['bib'][key], same_article['bib'][key])

--- a/test_module.py
+++ b/test_module.py
@@ -724,7 +724,7 @@ class TestScholarlyWithProxy(unittest.TestCase):
         pubs = list(scholarly.search_pubs('"naive physics" stability "3d shape"'))
         # Check that the first entry in pubs is the same as pub.
         # Checking for quality holds for non-dict entries only.
-        for key in {'author_id', 'pub_url', 'pdf_url', 'num_citations'}:
+        for key in {'author_id', 'pub_url', 'eprint_url', 'num_citations'}:
             self.assertEqual(pub[key], pubs[0][key])
         for key in {'title', 'pub_year', 'venue'}:
             self.assertEqual(pub['bib'][key], pubs[0]['bib'][key])
@@ -784,7 +784,7 @@ class TestScholarlyWithProxy(unittest.TestCase):
         self.assertTrue(f['bib']['publisher'] == u'The Association for Research in Vision and Ophthalmology')
         self.assertTrue(f['bib']['title'] == u'Creating correct blur and its effect on accommodation')
         self.assertTrue(f['pub_url'] == u'https://jov.arvojournals.org/article.aspx?articleid=2701817')
-        self.assertTrue(f['pdf_url'] == u'https://jov.arvojournals.org/arvo/content_public/journal/jov/937491/i1534-7362-18-9-1.pdf')
+        self.assertTrue(f['eprint_url'] == u'https://jov.arvojournals.org/arvo/content_public/journal/jov/937491/i1534-7362-18-9-1.pdf')
         self.assertTrue(f['bib']['volume'] == '18')
         self.assertTrue(f['bib']['pub_year'] == u'2018')
 
@@ -801,7 +801,7 @@ class TestScholarlyWithProxy(unittest.TestCase):
         # Typically, the same publication is returned as the most related article
         same_article = next(related_articles)
         self.assertEqual(pub["pub_url"], same_article["pub_url"])
-        self.assertEqual(pub["pdf_url"], same_article["pdf_url"])
+        self.assertEqual(pub["eprint_url"], same_article["eprint_url"])
         for key in {'title', 'pub_year'}:
             self.assertEqual(str(pub['bib'][key]), (same_article['bib'][key]))
 
@@ -820,7 +820,7 @@ class TestScholarlyWithProxy(unittest.TestCase):
         related_articles = scholarly.get_related_articles(pub)
         # Typically, the same publication is returned as the most related article
         same_article = next(related_articles)
-        for key in {'author_id', 'pub_url', 'pdf_url', 'num_citations'}:
+        for key in {'author_id', 'pub_url', 'eprint_url', 'num_citations'}:
             self.assertEqual(pub[key], same_article[key])
         for key in {'title', 'pub_year'}:
             self.assertEqual(pub['bib'][key], same_article['bib'][key])


### PR DESCRIPTION
Hi team, 

I noticed that Scholarly doesn't output the PDF link (only pub_url), so I'm attempting to add this feature. 

### Description

Edited PublicationParser() fill() in publication_parser.py to add HTML parsing for the pdf link. 

Example publication with pdf link: https://scholar.google.com/citations?view_op=view_citation&hl=en&user=ynWS968AAAAJ&citation_for_view=ynWS968AAAAJ:8xutWZnSdmoC
<img width="1090" alt="Screenshot of Google Scholar publication with PDF link" src="https://github.com/scholarly-python-package/scholarly/assets/1161837/267a54af-6c99-43bc-ad2a-c239981b371a">

## Checklist

- [x] Check that the base branch is set to `develop` and **not** `main`.
- [x] Ensure that the documentation will be consistent with the code upon merging.
- [x] Add a line or a few lines that check the new features added.
- [x] Ensure that unit tests pass.
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
