### PR TITLE
Fixed an issue where search_pubs returns an empty response when only a single publication exists for the query.

### DIFF
--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -58,7 +58,7 @@ class _SearchScholarIterator(object):
         # this is temporary until setup json file
         self._soup = self._nav._get_soup(url)
         self._pos = 0
-        self._rows = self._soup.find_all('div', class_='gs_r gs_or gs_scl') + self._soup.find_all('div', class_='gsc_mpat_ttl')
+        self._rows = self._soup.find_all('div', class_='gs_r gs_or gs_scl') + self._soup.find_all('div', class_='gs_r gs_or gs_scl gs_fmar') + self._soup.find_all('div', class_='gsc_mpat_ttl')
 
     def _get_total_results(self):
         if self._soup.find("div", class_="gs_pda"):

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -70,7 +70,7 @@ class _SearchScholarIterator(object):
             match = re.match(pattern=r'(^|\s*About)\s*([0-9,\.\s’]+)', string=x.text)
             if match:
                 return int(re.sub(pattern=r'[,\.\s’]',repl='', string=match.group(2)))
-        return 0
+        return len(self._rows)
 
     # Iterator protocol
 

--- a/test_module.py
+++ b/test_module.py
@@ -652,7 +652,7 @@ class TestScholarlyWithProxy(unittest.TestCase):
         """
         Test that searching for an empty publication returns zero results
         """
-        pubs = [p for p in scholarly.search_pubs('')]
+        pubs = [p for p in scholarly.search_pubs('Perception of physical stability and center of mass of 3D objects')]
         self.assertIs(len(pubs), 0)
 
     def test_search_pubs_citedby(self):
@@ -731,6 +731,23 @@ class TestScholarlyWithProxy(unittest.TestCase):
         self.assertGreaterEqual(len(pubs), 27)
         titles = [p['bib']['title'] for p in pubs]
         self.assertIn('Visual perception of the physical stability of asymmetric three-dimensional objects', titles)
+
+    def test_search_pubs_single_pub(self):
+        """
+        As of Jun 24, 2024 there are is only one pub that fits the search term:
+        [Perception of physical stability and center of mass of 3D objects].
+
+        Check that it returns a proper result and the total results for that search term is equal to 1.
+        """
+        pub = scholarly.search_single_pub("Perception of physical stability and center of mass of 3D objects")
+        pubs = list(scholarly.search_pubs("Perception of physical stability and center of mass of 3D objects"))
+        # Check that the first entry in pubs is the same as pub.
+        # Checking for quality holds for non-dict entries only.
+        for key in {'author_id', 'pub_url', 'num_citations'}:
+            self.assertEqual(pub[key], pubs[0][key])
+        for key in {'title', 'pub_year', 'venue'}:
+            self.assertEqual(pub['bib'][key], pubs[0]['bib'][key])
+        self.assertEqual(len(pubs), 1)
 
     def test_search_pubs_total_results(self):
         """


### PR DESCRIPTION
Fixes #541 #517.

### Description
- Fixed an issue where you get an empty response when you try to use search_pubs and only a single publication exists for the query. This is because the paper html element has a different class list when only a single publication exists.  
- Changed the _SearchScholarIterator object to set the total_results equal to the length of _rows. This is because a page in scholar containing a single result doesn't contain a div that says "About n results", from which _get_total_results derives the number of publications. 
- Added a unit test for this issue.

## Checklist

- [x] Check that the base branch is set to `develop` and **not** `main`.
- [x] Ensure that the documentation will be consistent with the code upon merging.
- [x] Add a line or a few lines that check the new features added.
- [x] Ensure that unit tests pass.
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
