### PR TITLE
Fallback to regex pub year exraction or empty string in case arrow fails to parse the date

### DIFF
--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -312,7 +312,11 @@ class PublicationParser(object):
                                 'YYYY/M/DD',
                                 'YYYY/M/D',
                                 'YYYY/MM/D']
-                    publication['bib']['pub_year'] = arrow.get(val.text, patterns).year
+                    try:
+                        publication['bib']['pub_year'] = arrow.get(val.text, patterns).year
+                    except ValueError:
+                        # fallback to regex year extraction if arrow fails
+                         publication['bib']['pub_year'] = re.search(r'\d{4}', val.text).group()
                     publication['bib']['pub_date'] = val.text
                 elif key == 'description':
                     # try to find all the gsh_csp if they exist

--- a/scholarly/publication_parser.py
+++ b/scholarly/publication_parser.py
@@ -316,7 +316,8 @@ class PublicationParser(object):
                         publication['bib']['pub_year'] = arrow.get(val.text, patterns).year
                     except ValueError:
                         # fallback to regex year extraction if arrow fails
-                         publication['bib']['pub_year'] = re.search(r'\d{4}', val.text).group()
+                        match = re.search(r'\d{4}', val.text)
+                        publication['bib']['pub_year'] = match.group() if match else ""
                     publication['bib']['pub_date'] = val.text
                 elif key == 'description':
                     # try to find all the gsh_csp if they exist


### PR DESCRIPTION
Fixes #562 

### Description
When arrow fails to parse the date (due to unexisting date) it raises a ValueError. Catch this Error and fallback to regex year extraction, if no match is found an empty String is stored for pub_year. 

## Checklist

- [X] Check that the base branch is set to `develop` and **not** `main`.
- [X] Ensure that the documentation will be consistent with the code upon merging.
- [X] Add a line or a few lines that check the new features added.
- [X] Ensure that unit tests pass.
        If you don't have a premium proxy, some of the tests will be skipped.
        The tests that are run should pass without raising
        `MaxTriesExceededException` or other exceptions.
